### PR TITLE
adding support for join_on to python bindings

### DIFF
--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -222,7 +222,8 @@ impl PyDataFrame {
         let df = self
             .df
             .as_ref()
-            .join_on(right.df.as_ref(), join_type, expr)?;
+            .clone()
+            .join_on(right.df.as_ref().clone(), join_type, expr)?;
         Ok(Self::new(df))
     }
 

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -214,34 +214,15 @@ impl PyDataFrame {
 
     /// Thin wrapper for datafusion-rust `join_on`
     /// Slightly modified from original `join` above.
-    fn join_on(
-            &self,
-            right: PyDataFrame,
-            on_exprs: Vec<PyExpr>,
-            how: &str,
-        ) -> PyResult<Self> {
-        let join_type = match how {
-            "inner" => JoinType::Inner,
-            "left" => JoinType::Left,
-            "right" => JoinType::Right,
-            "full" => JoinType::Full,
-            "semi" => JoinType::LeftSemi,
-            "anti" => JoinType::LeftAnti,
-            how => {
-                return Err(DataFusionError::Common(format!(
-                    "The join type {how} does not exist or is not implemented"
-                ))
-                .into());
-            }
-        };
+    fn join_on(&self, right: PyDataFrame, on_exprs: Vec<PyExpr>, how: &str) -> PyResult<Self> {
+        let join_type = JoinType::from_str(how)?;
 
-        let expr: Vec<_> = on_exprs.into_iter().map(|py_expr| py_expr.into()).collect();
+        let expr = on_exprs.into_iter().map(Into::into).collect();
 
-        let df = self.df.as_ref().clone().join_on(
-            right.df.as_ref().clone(),
-            join_type,
-            expr,
-        )?;
+        let df = self
+            .df
+            .as_ref()
+            .join_on(right.df.as_ref(), join_type, expr)?;
         Ok(Self::new(df))
     }
 

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -212,6 +212,39 @@ impl PyDataFrame {
         Ok(Self::new(df))
     }
 
+    /// Thin wrapper for datafusion-rust `join_on`
+    /// Slightly modified from original `join` above.
+    fn join_on(
+            &self,
+            right: PyDataFrame,
+            on_exprs: Vec<PyExpr>,
+            how: &str,
+        ) -> PyResult<Self> {
+        let join_type = match how {
+            "inner" => JoinType::Inner,
+            "left" => JoinType::Left,
+            "right" => JoinType::Right,
+            "full" => JoinType::Full,
+            "semi" => JoinType::LeftSemi,
+            "anti" => JoinType::LeftAnti,
+            how => {
+                return Err(DataFusionError::Common(format!(
+                    "The join type {how} does not exist or is not implemented"
+                ))
+                .into());
+            }
+        };
+
+        let expr: Vec<_> = on_exprs.into_iter().map(|py_expr| py_expr.into()).collect();
+
+        let df = self.df.as_ref().clone().join_on(
+            right.df.as_ref().clone(),
+            join_type,
+            expr,
+        )?;
+        Ok(Self::new(df))
+    }
+
     /// Print the query plan
     #[pyo3(signature = (verbose=false, analyze=false))]
     fn explain(&self, py: Python, verbose: bool, analyze: bool) -> PyResult<()> {


### PR DESCRIPTION
# Which issue does this PR close?
Should close https://github.com/apache/arrow-datafusion-python/issues/323

# What changes are included in this PR?
# Are there any user-facing changes?
Yes there are user facing changes, namely we're extending the PyDataFrame to also expose the underlying `join_on`

# More

This PR is mostly to provoke the discussion. If there's some existing reason we don't expose it, or perhaps extend `join` to support it, please let me know. Just looking for some feedback. Thanks!