### PR TITLE
docs: update docs CI to install python-311 requirements

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -48,7 +48,7 @@ jobs:
           set -x
           python3 -m venv venv
           source venv/bin/activate
-          pip install -r requirements-310.txt
+          pip install -r requirements-311.txt
           pip install -r docs/requirements.txt
       - name: Build Datafusion
         run: |


### PR DESCRIPTION

# Which issue does this PR close?

Closes #644 (hopefully)

 # Rationale for this change

PR #645 switched to using python 3.11 to publish docs. This updates the dependency installation to use the appropriate requirements file.

# What changes are included in this PR?
none

# Are there any user-facing changes?
none
