### PR TITLE
Fix Docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,6 +4,9 @@ on:
       - main
     tags-ignore:
       - "**-rc**"
+  pull_request:
+    branches:
+      - main
 
 name: Deploy DataFusion Python site
 
@@ -13,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set target branch
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: target-branch
         run: |
           set -x
@@ -27,6 +31,7 @@ jobs:
       - name: Checkout docs sources
         uses: actions/checkout@v3
       - name: Checkout docs target branch
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -64,6 +69,7 @@ jobs:
           make html
 
       - name: Copy & push the generated HTML
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           set -x
           cd docs-target

--- a/docs/source/api/object_store.rst
+++ b/docs/source/api/object_store.rst
@@ -19,7 +19,7 @@
 .. currentmodule:: datafusion.object_store
 
 ObjectStore
-=========
+===========
 
 .. autosummary::
    :toctree: ../generated/

--- a/docs/source/user-guide/common-operations/functions.rst
+++ b/docs/source/user-guide/common-operations/functions.rst
@@ -92,13 +92,12 @@ DataFusion offers a range of helpful options.
         f.left(col('"Name"'), literal(4)).alias("code")
     )
 
-This also includes the functions for regular expressions :func:`.regexp_replace` and :func:`.regexp_match`
+This also includes the functions for regular expressions like :func:`.regexp_match`
 
 .. ipython:: python
 
     df.select(
         f.regexp_match(col('"Name"'), literal("Char")).alias("dragons"),
-        f.regexp_replace(col('"Name"'), literal("saur"), literal("fleur")).alias("flowers")
     )
 
 

--- a/docs/source/user-guide/configuration.rst
+++ b/docs/source/user-guide/configuration.rst
@@ -16,7 +16,7 @@
 .. under the License.
 
 Configuration
-========
+=============
 
 Let's look at how we can configure DataFusion. When creating a :code:`SessionContext`, you can pass in
 a :code:`SessionConfig` and :code:`RuntimeConfig` object. These two cover a wide range of options.
@@ -48,4 +48,4 @@ a :code:`SessionConfig` and :code:`RuntimeConfig` object. These two cover a wide
 
 
 You can read more about available :code:`SessionConfig` options `here <https://arrow.apache.org/datafusion/user-guide/configs.html>`_,
-and about :code:`RuntimeConfig` options `here https://docs.rs/datafusion/latest/datafusion/execution/runtime_env/struct.RuntimeConfig.html`_.
+and about :code:`RuntimeConfig` options `here <https://docs.rs/datafusion/latest/datafusion/execution/runtime_env/struct.RuntimeConfig.html>`_.


### PR DESCRIPTION
# Which issue does this PR close?

Closes #675

 # Rationale for this change


# What changes are included in this PR?
1) Remove offending function call `regex_replace` from docs. This will be added back once upstream datafusion figures out optional arguments to UDFs.
2) Update the `docs` github action to run on pull requests but only deploy when it hits main.