### PR TITLE
fix conda nightly builds, attempt 2

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -81,6 +81,9 @@ jobs:
           which python
           pip list
           mamba list
+      # Clean the conda cache
+      - name: Clean Conda Cache
+        run: conda clean --all --yes
       - name: Build conda packages
         run: |
           # suffix for nightly package versions


### PR DESCRIPTION
# Which issue does this PR close?

Closes #659 .

 # Rationale for this change

My prior attempt failed at this failed (#664), but I *believe* that was because [conda didn't like](https://github.com/apache/datafusion-python/issues/659#issuecomment-2100566566) the tag `publish-docs` on main.

I was able to reproduce the CI error locally, and running `conda clean` solved it.

# What changes are included in this PR?
Extra build step to CI.

# Are there any user-facing changes?
No.