### PR TITLE
feat: add python bindings for ends_with function

### DIFF
--- a/python/datafusion/tests/test_functions.py
+++ b/python/datafusion/tests/test_functions.py
@@ -533,6 +533,7 @@ def test_string_functions(df):
         f.translate(column("a"), literal("or"), literal("ld")),
         f.trim(column("c")),
         f.upper(column("c")),
+        f.ends_with(column("a"), literal("llo")),
     )
     result = df.collect()
     assert len(result) == 1
@@ -573,6 +574,7 @@ def test_string_functions(df):
     assert result.column(25) == pa.array(["Helll", "Wldld", "!"])
     assert result.column(26) == pa.array(["hello", "world", "!"])
     assert result.column(27) == pa.array(["HELLO ", " WORLD ", " !"])
+    assert result.column(22) == pa.array([True, False, False])
 
 
 def test_hash_functions(df):

--- a/python/datafusion/tests/test_functions.py
+++ b/python/datafusion/tests/test_functions.py
@@ -574,7 +574,7 @@ def test_string_functions(df):
     assert result.column(25) == pa.array(["Helll", "Wldld", "!"])
     assert result.column(26) == pa.array(["hello", "world", "!"])
     assert result.column(27) == pa.array(["HELLO ", " WORLD ", " !"])
-    assert result.column(22) == pa.array([True, False, False])
+    assert result.column(28) == pa.array([True, False, False])
 
 
 def test_hash_functions(df):

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -708,6 +708,7 @@ pub(crate) fn init_module(m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(split_part))?;
     m.add_wrapped(wrap_pyfunction!(sqrt))?;
     m.add_wrapped(wrap_pyfunction!(starts_with))?;
+    m.add_wrapped(wrap_pyfunction!(ends_with))?;
     m.add_wrapped(wrap_pyfunction!(stddev))?;
     m.add_wrapped(wrap_pyfunction!(stddev_pop))?;
     m.add_wrapped(wrap_pyfunction!(stddev_samp))?;

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -653,6 +653,7 @@ pub(crate) fn init_module(m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(datetrunc))?;
     m.add_wrapped(wrap_pyfunction!(date_trunc))?;
     m.add_wrapped(wrap_pyfunction!(digest))?;
+    m.add_wrapped(wrap_pyfunction!(ends_with))?;
     m.add_wrapped(wrap_pyfunction!(exp))?;
     m.add_wrapped(wrap_pyfunction!(factorial))?;
     m.add_wrapped(wrap_pyfunction!(floor))?;
@@ -708,7 +709,6 @@ pub(crate) fn init_module(m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(split_part))?;
     m.add_wrapped(wrap_pyfunction!(sqrt))?;
     m.add_wrapped(wrap_pyfunction!(starts_with))?;
-    m.add_wrapped(wrap_pyfunction!(ends_with))?;
     m.add_wrapped(wrap_pyfunction!(stddev))?;
     m.add_wrapped(wrap_pyfunction!(stddev_pop))?;
     m.add_wrapped(wrap_pyfunction!(stddev_samp))?;

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -474,6 +474,7 @@ expr_fn!(
 );
 expr_fn!(sqrt, num);
 expr_fn!(starts_with, arg1 arg2, "Returns true if string starts with prefix.");
+expr_fn!(ends_with, arg1 arg2, "Returns true if string ends with suffix.");
 expr_fn!(strpos, string substring, "Returns starting index of specified substring within string, or zero if it's not present. (Same as position(substring in string), but note the reversed argument order.)");
 expr_fn!(substr, string position);
 expr_fn!(tan, num);

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -407,6 +407,7 @@ expr_fn!(cosh, num);
 expr_fn!(degrees, num);
 expr_fn!(decode, input encoding);
 expr_fn!(encode, input encoding);
+expr_fn!(ends_with, string suffix, "Returns true if string ends with suffix.");
 expr_fn!(exp, num);
 expr_fn!(factorial, num);
 expr_fn!(floor, num);
@@ -473,8 +474,7 @@ expr_fn!(
     "Splits string at occurrences of delimiter and returns the n'th field (counting from one)."
 );
 expr_fn!(sqrt, num);
-expr_fn!(starts_with, arg1 arg2, "Returns true if string starts with prefix.");
-expr_fn!(ends_with, arg1 arg2, "Returns true if string ends with suffix.");
+expr_fn!(starts_with, string prefix, "Returns true if string starts with prefix.");
 expr_fn!(strpos, string substring, "Returns starting index of specified substring within string, or zero if it's not present. (Same as position(substring in string), but note the reversed argument order.)");
 expr_fn!(substr, string position);
 expr_fn!(tan, num);


### PR DESCRIPTION
# Which issue does this PR close?

ends_with function is missing from datafusion_python

