### PR TITLE
fix `lib.name` in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ url = "2.2"
 pyo3-build-config = "0.20.0"
 
 [lib]
-name = "datafusion_python"
+name = "_internal"
 crate-type = ["cdylib", "rlib"]
 
 [profile.release]


### PR DESCRIPTION
With the current settings `maturin build` and `pip install .` gave me an error when I tried to import `datafusion`:

```
Traceback (most recent call last):
  File "/Users/samuel/code/datafusion-python/demo.py", line 1, in <module>
    from datafusion import SessionContext
  File "/Users/samuel/code/datafusion-python/datafusion/__init__.py", line 28, in <module>
    from ._internal import (
ModuleNotFoundError: No module named 'datafusion._internal'
```