### PR TITLE
ci: add substrait feature to linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,7 +189,7 @@ jobs:
           target: x86_64
           manylinux: auto
           rustup-components: rust-std rustfmt # Keep them in one line due to https://github.com/PyO3/maturin-action/issues/153
-          args: --release --manylinux 2014 --features protoc
+          args: --release --manylinux 2014 --features protoc,substrait
       - name: Archive wheels
         uses: actions/upload-artifact@v3
         with:
@@ -219,7 +219,7 @@ jobs:
           # Use manylinux_2_28-cross because the manylinux2014-cross has GCC 4.8.5, which causes the build to fail
           manylinux: 2_28
           rustup-components: rust-std rustfmt # Keep them in one line due to https://github.com/PyO3/maturin-action/issues/153
-          args: --release --features protoc
+          args: --release --features protoc,substrait
       - name: Archive wheels
         uses: actions/upload-artifact@v3
         with:
@@ -245,7 +245,7 @@ jobs:
           rust-toolchain: stable
           manylinux: auto
           rustup-components: rust-std rustfmt
-          args: --release --sdist --out dist --features protoc
+          args: --release --sdist --out dist --features protoc,substrait
       - name: Archive wheels
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
# Which issue does this PR close?

Closes #646.

 # Rationale for this change
These build steps were setting `--features protoc`, which I think was over-riding the `features = ["substrait"]` in `pyproject.toml`

# Are there any user-facing changes?
There should not be.