### PR TITLE
Docs deploy action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,15 @@ on:
 name: Deploy DataFusion Python site
 
 jobs:
+  debug-github-context:    
+    name: Print github context
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: |
+        echo "$GITHUB_CONTEXT"
   build-docs:
     name: Build docs
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set target branch
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
         id: target-branch
         run: |
           set -x
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout docs sources
         uses: actions/checkout@v3
       - name: Checkout docs target branch
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -78,7 +78,7 @@ jobs:
           make html
 
       - name: Copy & push the generated HTML
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
         run: |
           set -x
           cd docs-target


### PR DESCRIPTION


 # Rationale for this change

I *think* the condition for deploying the docs was wrong. When a tag is pushed to `main`, the `github.ref` is the tag, not the branch name.

I also added a debug print step because I'm uncertain and would like to verify.

