### PR TITLE
use ScalarValue::to_pyarrow to convert to python object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,6 +1032,7 @@ dependencies = [
 name = "datafusion-python"
 version = "39.0.0"
 dependencies = [
+ "arrow",
  "async-trait",
  "datafusion",
  "datafusion-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ substrait = ["dep:datafusion-substrait"]
 tokio = { version = "1.35", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 rand = "0.8"
 pyo3 = { version = "0.21", features = ["extension-module", "abi3", "abi3-py38", "gil-refs"] }
+arrow = { version = "52", feature = ["pyarrow"] }
 datafusion = { version = "39.0.0", features = ["pyarrow", "avro", "unicode_expressions"] }
 datafusion-common = { version = "39.0.0", features = ["pyarrow"] }
 datafusion-expr = "39.0.0"


### PR DESCRIPTION


# Which issue does this PR close?

Closes #729

 # Rationale for this change
`datafusion` already implements converting `ScalarValue`s to python objects.

# What changes are included in this PR?

# Are there any user-facing changes?
ScalarValue types that we hadn't converted like Float16, BigDecimal128 will now be supported.

It should be strictly additive, I think.