### PR TITLE
Pyo3 `Bound<'py, T>` api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ substrait = ["dep:datafusion-substrait"]
 [dependencies]
 tokio = { version = "1.35", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 rand = "0.8"
-pyo3 = { version = "0.21", features = ["extension-module", "abi3", "abi3-py38", "gil-refs"] }
+pyo3 = { version = "0.21", features = ["extension-module", "abi3", "abi3-py38"] }
 arrow = { version = "52", feature = ["pyarrow"] }
 datafusion = { version = "39.0.0", features = ["pyarrow", "avro", "unicode_expressions"] }
 datafusion-common = { version = "39.0.0", features = ["pyarrow"] }
@@ -67,3 +67,4 @@ crate-type = ["cdylib", "rlib"]
 [profile.release]
 lto = true
 codegen-units = 1
+    

--- a/src/common.rs
+++ b/src/common.rs
@@ -23,7 +23,7 @@ pub mod function;
 pub mod schema;
 
 /// Initializes the `common` module to match the pattern of `datafusion-common` https://docs.rs/datafusion-common/18.0.0/datafusion_common/index.html
-pub(crate) fn init_module(m: &PyModule) -> PyResult<()> {
+pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<df_schema::PyDFSchema>()?;
     m.add_class::<data_type::PyDataType>()?;
     m.add_class::<data_type::DataTypeMap>()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,7 @@ impl PyConfig {
 
     /// Get all configuration options
     pub fn get_all(&mut self, py: Python) -> PyResult<PyObject> {
-        let dict = PyDict::new(py);
+        let dict = PyDict::new_bound(py);
         let options = self.config.to_owned();
         for entry in options.entries() {
             dict.set_item(entry.key, entry.value.clone().into_py(py))?;

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -553,7 +553,7 @@ impl PyExpr {
 }
 
 /// Initializes the `expr` module to match the pattern of `datafusion-expr` https://docs.rs/datafusion-expr/latest/datafusion_expr/
-pub(crate) fn init_module(m: &PyModule) -> PyResult<()> {
+pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyExpr>()?;
     m.add_class::<PyColumn>()?;
     m.add_class::<PyLiteral>()?;

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -670,7 +670,7 @@ aggregate_function!(bit_xor, BitXor);
 aggregate_function!(bool_and, BoolAnd);
 aggregate_function!(bool_or, BoolOr);
 
-pub(crate) fn init_module(m: &PyModule) -> PyResult<()> {
+pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(abs))?;
     m.add_wrapped(wrap_pyfunction!(acos))?;
     m.add_wrapped(wrap_pyfunction!(acosh))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub(crate) struct TokioRuntime(tokio::runtime::Runtime);
 /// The higher-level public API is defined in pure python files under the
 /// datafusion directory.
 #[pymodule]
-fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
+fn _internal(py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     // Register the Tokio Runtime as a module attribute so we can reuse it
     m.add(
         "runtime",
@@ -94,35 +94,35 @@ fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<physical_plan::PyExecutionPlan>()?;
 
     // Register `common` as a submodule. Matching `datafusion-common` https://docs.rs/datafusion-common/latest/datafusion_common/
-    let common = PyModule::new(py, "common")?;
-    common::init_module(common)?;
-    m.add_submodule(common)?;
+    let common = PyModule::new_bound(py, "common")?;
+    common::init_module(&common)?;
+    m.add_submodule(&common)?;
 
     // Register `expr` as a submodule. Matching `datafusion-expr` https://docs.rs/datafusion-expr/latest/datafusion_expr/
-    let expr = PyModule::new(py, "expr")?;
-    expr::init_module(expr)?;
-    m.add_submodule(expr)?;
+    let expr = PyModule::new_bound(py, "expr")?;
+    expr::init_module(&expr)?;
+    m.add_submodule(&expr)?;
 
     // Register the functions as a submodule
-    let funcs = PyModule::new(py, "functions")?;
-    functions::init_module(funcs)?;
-    m.add_submodule(funcs)?;
+    let funcs = PyModule::new_bound(py, "functions")?;
+    functions::init_module(&funcs)?;
+    m.add_submodule(&funcs)?;
 
-    let store = PyModule::new(py, "object_store")?;
-    store::init_module(store)?;
-    m.add_submodule(store)?;
+    let store = PyModule::new_bound(py, "object_store")?;
+    store::init_module(&store)?;
+    m.add_submodule(&store)?;
 
     // Register substrait as a submodule
     #[cfg(feature = "substrait")]
-    setup_substrait_module(py, m)?;
+    setup_substrait_module(py, &m)?;
 
     Ok(())
 }
 
 #[cfg(feature = "substrait")]
-fn setup_substrait_module(py: Python, m: &PyModule) -> PyResult<()> {
-    let substrait = PyModule::new(py, "substrait")?;
-    substrait::init_module(substrait)?;
-    m.add_submodule(substrait)?;
+fn setup_substrait_module(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let substrait = PyModule::new_bound(py, "substrait")?;
+    substrait::init_module(&substrait)?;
+    m.add_submodule(&substrait)?;
     Ok(())
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -219,7 +219,7 @@ impl PyAmazonS3Context {
     }
 }
 
-pub(crate) fn init_module(m: &PyModule) -> PyResult<()> {
+pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyAmazonS3Context>()?;
     m.add_class::<PyMicrosoftAzureContext>()?;
     m.add_class::<PyGoogleCloudContext>()?;

--- a/src/substrait.rs
+++ b/src/substrait.rs
@@ -140,7 +140,7 @@ impl PySubstraitConsumer {
     }
 }
 
-pub fn init_module(m: &PyModule) -> PyResult<()> {
+pub fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyPlan>()?;
     m.add_class::<PySubstraitConsumer>()?;
     m.add_class::<PySubstraitProducer>()?;

--- a/src/substrait.rs
+++ b/src/substrait.rs
@@ -40,7 +40,7 @@ impl PyPlan {
         self.plan
             .encode(&mut proto_bytes)
             .map_err(DataFusionError::EncodeError)?;
-        Ok(PyBytes::new(py, &proto_bytes).into())
+        Ok(PyBytes::new_bound(py, &proto_bytes).unbind().into())
     }
 }
 
@@ -76,7 +76,7 @@ impl PySubstraitSerializer {
     pub fn serialize_to_plan(sql: &str, ctx: PySessionContext, py: Python) -> PyResult<PyPlan> {
         match PySubstraitSerializer::serialize_bytes(sql, ctx, py) {
             Ok(proto_bytes) => {
-                let proto_bytes: &PyBytes = proto_bytes.as_ref(py).downcast().unwrap();
+                let proto_bytes = proto_bytes.bind(py).downcast::<PyBytes>().unwrap();
                 PySubstraitSerializer::deserialize_bytes(proto_bytes.as_bytes().to_vec(), py)
             }
             Err(e) => Err(py_datafusion_err(e)),
@@ -87,7 +87,7 @@ impl PySubstraitSerializer {
     pub fn serialize_bytes(sql: &str, ctx: PySessionContext, py: Python) -> PyResult<PyObject> {
         let proto_bytes: Vec<u8> = wait_for_future(py, serializer::serialize_bytes(sql, &ctx.ctx))
             .map_err(DataFusionError::from)?;
-        Ok(PyBytes::new(py, &proto_bytes).into())
+        Ok(PyBytes::new_bound(py, &proto_bytes).unbind().into())
     }
 
     #[staticmethod]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,13 +24,13 @@ use tokio::runtime::Runtime;
 
 /// Utility to get the Tokio Runtime from Python
 pub(crate) fn get_tokio_runtime(py: Python) -> PyRef<TokioRuntime> {
-    let datafusion = py.import("datafusion._internal").unwrap();
+    let datafusion = py.import_bound("datafusion._internal").unwrap();
     let tmp = datafusion.getattr("runtime").unwrap();
     match tmp.extract::<PyRef<TokioRuntime>>() {
         Ok(runtime) => runtime,
         Err(_e) => {
             let rt = TokioRuntime(tokio::runtime::Runtime::new().unwrap());
-            let obj: &PyAny = Py::new(py, rt).unwrap().into_ref(py);
+            let obj: Bound<'_, TokioRuntime> = Py::new(py, rt).unwrap().into_bound(py);
             obj.extract().unwrap()
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?

Part of #727 

 # Rationale for this change
`pyo3` has deprecated their gil-refs api.

See the [blog announcement](https://polar.sh/davidhewitt/posts/replacing-pyo3-api-pt1) and the [migration guide](https://pyo3.rs/v0.21.0/migration#from-020-to-021).


# What changes are included in this PR?
Migrates to pyo3's `Bound` api

# Are there any user-facing changes?
There should not be.