### PR TITLE
Pyo3 refactorings

### DIFF
--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -423,17 +423,15 @@ impl PyDataFrame {
 
     /// Convert to Arrow Table
     /// Collect the batches and pass to Arrow Table
-    fn to_arrow_table(&self, py: Python) -> PyResult<PyObject> {
+    fn to_arrow_table(&self, py: Python<'_>) -> PyResult<PyObject> {
         let batches = self.collect(py)?.to_object(py);
         let schema: PyObject = self.schema().into_py(py);
 
-        Python::with_gil(|py| {
-            // Instantiate pyarrow Table object and use its from_batches method
-            let table_class = py.import_bound("pyarrow")?.getattr("Table")?;
-            let args = PyTuple::new_bound(py, &[batches, schema]);
-            let table: PyObject = table_class.call_method1("from_batches", args)?.into();
-            Ok(table)
-        })
+        // Instantiate pyarrow Table object and use its from_batches method
+        let table_class = py.import_bound("pyarrow")?.getattr("Table")?;
+        let args = PyTuple::new_bound(py, &[batches, schema]);
+        let table: PyObject = table_class.call_method1("from_batches", args)?.into();
+        Ok(table)
     }
 
     fn execute_stream(&self, py: Python) -> PyResult<PyRecordBatchStream> {
@@ -464,26 +462,22 @@ impl PyDataFrame {
 
     /// Convert to pandas dataframe with pyarrow
     /// Collect the batches, pass to Arrow Table & then convert to Pandas DataFrame
-    fn to_pandas(&self, py: Python) -> PyResult<PyObject> {
+    fn to_pandas(&self, py: Python<'_>) -> PyResult<PyObject> {
         let table = self.to_arrow_table(py)?;
 
-        Python::with_gil(|py| {
-            // See also: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas
-            let result = table.call_method0(py, "to_pandas")?;
-            Ok(result)
-        })
+        // See also: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas
+        let result = table.call_method0(py, "to_pandas")?;
+        Ok(result)
     }
 
     /// Convert to Python list using pyarrow
     /// Each list item represents one row encoded as dictionary
-    fn to_pylist(&self, py: Python) -> PyResult<PyObject> {
+    fn to_pylist(&self, py: Python<'_>) -> PyResult<PyObject> {
         let table = self.to_arrow_table(py)?;
 
-        Python::with_gil(|py| {
-            // See also: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pylist
-            let result = table.call_method0(py, "to_pylist")?;
-            Ok(result)
-        })
+        // See also: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pylist
+        let result = table.call_method0(py, "to_pylist")?;
+        Ok(result)
     }
 
     /// Convert to Python dictionary using pyarrow
@@ -491,24 +485,19 @@ impl PyDataFrame {
     fn to_pydict(&self, py: Python) -> PyResult<PyObject> {
         let table = self.to_arrow_table(py)?;
 
-        Python::with_gil(|py| {
-            // See also: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pydict
-            let result = table.call_method0(py, "to_pydict")?;
-            Ok(result)
-        })
+        // See also: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pydict
+        let result = table.call_method0(py, "to_pydict")?;
+        Ok(result)
     }
 
     /// Convert to polars dataframe with pyarrow
     /// Collect the batches, pass to Arrow Table & then convert to polars DataFrame
-    fn to_polars(&self, py: Python) -> PyResult<PyObject> {
+    fn to_polars(&self, py: Python<'_>) -> PyResult<PyObject> {
         let table = self.to_arrow_table(py)?;
-
-        Python::with_gil(|py| {
-            let dataframe = py.import_bound("polars")?.getattr("DataFrame")?;
-            let args = PyTuple::new_bound(py, &[table]);
-            let result: PyObject = dataframe.call1(args)?.into();
-            Ok(result)
-        })
+        let dataframe = py.import_bound("polars")?.getattr("DataFrame")?;
+        let args = PyTuple::new_bound(py, &[table]);
+        let result: PyObject = dataframe.call1(args)?.into();
+        Ok(result)
     }
 
     // Executes this DataFrame to get the total number of rows.

--- a/src/sql/logical.rs
+++ b/src/sql/logical.rs
@@ -63,7 +63,7 @@ impl PyLogicalPlan {
 impl PyLogicalPlan {
     /// Return the specific logical operator
     pub fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Python::with_gil(|_| match self.plan.as_ref() {
+        match self.plan.as_ref() {
             LogicalPlan::Aggregate(plan) => PyAggregate::from(plan.clone()).to_variant(py),
             LogicalPlan::Analyze(plan) => PyAnalyze::from(plan.clone()).to_variant(py),
             LogicalPlan::CrossJoin(plan) => PyCrossJoin::from(plan.clone()).to_variant(py),
@@ -85,7 +85,7 @@ impl PyLogicalPlan {
                 "Cannot convert this plan to a LogicalNode: {:?}",
                 other
             ))),
-        })
+        }
     }
 
     /// Get the inputs to this plan


### PR DESCRIPTION
# Which issue does this PR close?

Part of #727.

# Rationale for this change
[pyo3 recommend](https://github.com/PyO3/pyo3/pull/4274) using the Python token from a `Bound<'_, T>` type or automatically passed in as a method parameter for a `#[pymethods]` or `#[pyfunction]` because they are zero-cost.

`Python::with_gil` carries a runtime check overhead.

# What changes are included in this PR?
I changed all the places that had straightforward removal of `Python::with_gil`. 

Additionally, I removed some manual type conversion work by letting pyo3 do it automatically as we cross the python-rust boundary.

# Are there any user-facing changes?
No