### PR TITLE
Expose the correct namespaces for Python modules

### DIFF
--- a/python/datafusion/__init__.py
+++ b/python/datafusion/__init__.py
@@ -88,66 +88,6 @@ from .expr import (
 
 __version__ = importlib_metadata.version(__name__)
 
-__all__ = [
-    "Config",
-    "DataFrame",
-    "SessionContext",
-    "SessionConfig",
-    "SQLOptions",
-    "RuntimeConfig",
-    "Expr",
-    "AggregateUDF",
-    "ScalarUDF",
-    "Window",
-    "WindowFrame",
-    "column",
-    "literal",
-    "TableScan",
-    "Projection",
-    "DFSchema",
-    "DFField",
-    "Analyze",
-    "Sort",
-    "Limit",
-    "Filter",
-    "Like",
-    "ILike",
-    "SimilarTo",
-    "ScalarVariable",
-    "Alias",
-    "Not",
-    "IsNotNull",
-    "IsTrue",
-    "IsFalse",
-    "IsUnknown",
-    "IsNotTrue",
-    "IsNotFalse",
-    "IsNotUnknown",
-    "Negative",
-    "ScalarFunction",
-    "BuiltinScalarFunction",
-    "InList",
-    "Exists",
-    "Subquery",
-    "InSubquery",
-    "ScalarSubquery",
-    "GroupingSet",
-    "Placeholder",
-    "Case",
-    "Cast",
-    "TryCast",
-    "Between",
-    "Explain",
-    "SubqueryAlias",
-    "Extension",
-    "CreateMemoryTable",
-    "CreateView",
-    "Distinct",
-    "DropTable",
-    "Repartition",
-    "Partitioning",
-]
-
 
 class Accumulator(metaclass=ABCMeta):
     @abstractmethod
@@ -175,6 +115,8 @@ col = column
 
 
 def literal(value):
+    import pyarrow as pa
+
     if not isinstance(value, pa.Scalar):
         value = pa.scalar(value)
     return Expr.literal(value)
@@ -204,6 +146,8 @@ def udaf(accum, input_type, return_type, state_type, volatility, name=None):
     """
     Create a new User Defined Aggregate Function
     """
+    import pyarrow as pa
+
     if not issubclass(accum, Accumulator):
         raise TypeError("`accum` must implement the abstract base class Accumulator")
     if name is None:
@@ -218,3 +162,68 @@ def udaf(accum, input_type, return_type, state_type, volatility, name=None):
         state_type=state_type,
         volatility=volatility,
     )
+
+
+del ABCMeta
+del abstractmethod
+del List
+del importlib_metadata
+del pa
+
+
+__all__ = [
+    "Config",
+    "DataFrame",
+    "SessionContext",
+    "SessionConfig",
+    "SQLOptions",
+    "RuntimeConfig",
+    "Expr",
+    "AggregateUDF",
+    "ScalarUDF",
+    "Window",
+    "WindowFrame",
+    "column",
+    "literal",
+    "TableScan",
+    "Projection",
+    "DFSchema",
+    "Analyze",
+    "Sort",
+    "Limit",
+    "Filter",
+    "Like",
+    "ILike",
+    "SimilarTo",
+    "ScalarVariable",
+    "Alias",
+    "Not",
+    "IsNotNull",
+    "IsTrue",
+    "IsFalse",
+    "IsUnknown",
+    "IsNotTrue",
+    "IsNotFalse",
+    "IsNotUnknown",
+    "Negative",
+    "InList",
+    "Exists",
+    "Subquery",
+    "InSubquery",
+    "ScalarSubquery",
+    "GroupingSet",
+    "Placeholder",
+    "Case",
+    "Cast",
+    "TryCast",
+    "Between",
+    "Explain",
+    "SubqueryAlias",
+    "Extension",
+    "CreateMemoryTable",
+    "CreateView",
+    "Distinct",
+    "DropTable",
+    "Repartition",
+    "Partitioning",
+]

--- a/python/datafusion/common.py
+++ b/python/datafusion/common.py
@@ -16,8 +16,15 @@
 # under the License.
 
 
-from ._internal import common
-
-
 def __getattr__(name):
+    from ._internal import common
+
     return getattr(common, name)
+
+
+def __dir__():
+    from ._internal import common
+
+    return list(globals().keys()) + [
+        obj for obj in dir(common) if not obj.startswith("_")
+    ]

--- a/python/datafusion/expr.py
+++ b/python/datafusion/expr.py
@@ -16,8 +16,15 @@
 # under the License.
 
 
-from ._internal import expr
-
-
 def __getattr__(name):
+    from ._internal import expr
+
     return getattr(expr, name)
+
+
+def __dir__():
+    from ._internal import expr
+
+    return list(globals().keys()) + [
+        obj for obj in dir(expr) if not obj.startswith("_")
+    ]

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -16,8 +16,15 @@
 # under the License.
 
 
-from ._internal import functions
-
-
 def __getattr__(name):
+    from ._internal import functions
+
     return getattr(functions, name)
+
+
+def __dir__():
+    from ._internal import functions
+
+    return list(globals().keys()) + [
+        obj for obj in dir(functions) if not obj.startswith("_")
+    ]

--- a/python/datafusion/object_store.py
+++ b/python/datafusion/object_store.py
@@ -16,8 +16,15 @@
 # under the License.
 
 
-from ._internal import object_store
-
-
 def __getattr__(name):
+    from ._internal import object_store
+
     return getattr(object_store, name)
+
+
+def __dir__():
+    from ._internal import object_store
+
+    return list(globals().keys()) + [
+        obj for obj in dir(object_store) if not obj.startswith("_")
+    ]

--- a/python/datafusion/substrait.py
+++ b/python/datafusion/substrait.py
@@ -16,8 +16,15 @@
 # under the License.
 
 
-from ._internal import substrait
-
-
 def __getattr__(name):
+    from ._internal import substrait
+
     return getattr(substrait, name)
+
+
+def __dir__():
+    from ._internal import substrait
+
+    return list(globals().keys()) + [
+        obj for obj in dir(substrait) if not obj.startswith("_")
+    ]


### PR DESCRIPTION
Currently, in the `datafusion` module there is no match between what `dir()` returns, and what's actually inside the module. For example:

```python
>>> import datafusion

>>> dir(datafusion)
['ABCMeta', 'Accumulator', 'AggregateUDF', 'Alias', 'Analyze', 'Between', 'Case', 'Cast', 'Config', 'CreateMemoryTable', 'CreateView', 'DFSchema', 'DataFrame', 'Distinct', 'DropTable', 'Exists', 'Explain', 'Expr', 'Extension', 'Filter', 'GroupingSet', 'ILike', 'InList', 'InSubquery', 'IsFalse', 'IsNotFalse', 'IsNotNull', 'IsNotTrue', 'IsNotUnknown', 'IsTrue', 'IsUnknown', 'Like', 'Limit', 'List', 'Negative', 'Not', 'Partitioning', 'Placeholder', 'Projection', 'Repartition', 'RuntimeConfig', 'SQLOptions', 'ScalarSubquery', 'ScalarUDF', 'ScalarVariable', 'SessionConfig', 'SessionContext', 'SimilarTo', 'Sort', 'Subquery', 'SubqueryAlias', 'TableScan', 'TryCast', 'Window', 'WindowFrame', '__all__', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', '_internal', 'abstractmethod', 'col', 'column', 'common', 'expr', 'importlib_metadata', 'lit', 'literal', 'pa', 'udaf', 'udf']

>>> datafusion.ABCMeta  # <- THIS IS A STANDARD LIBRARY CLASS, NOT PART OF DATAFUSION
<class 'abc.ABCMeta'>

>>> dir(datafusion.common)  # <- BASED ON THIS, THERE IS NOTHING IN THE MODULE EXCEPT THE MODULE ITSELF AGAIN
['__builtins__', '__cached__', '__doc__', '__file__', '__getattr__', '__loader__', '__name__', '__package__', '__spec__', 'common']

>>> datafusion.common.common
<module 'common'>

>>> datafusion.common.SqlTable  # <- BUT WHEN USING THE MODULE THERE ARE ACTUALLY CLASSES
<class 'datafusion.common.SqlTable'>
```

With this PR, I basically show what is part of the module, and I hide what's being displayed now as a side effect:

```python
>>> import datafusion

>>> dir(datafusion)
['Accumulator', 'AggregateUDF', 'Alias', 'Analyze', 'Between', 'Case', 'Cast', 'Config', 'CreateMemoryTable', 'CreateView', 'DFSchema', 'DataFrame', 'Distinct', 'DropTable', 'Exists', 'Explain', 'Expr', 'Extension', 'Filter', 'GroupingSet', 'ILike', 'InList', 'InSubquery', 'IsFalse', 'IsNotFalse', 'IsNotNull', 'IsNotTrue', 'IsNotUnknown', 'IsTrue', 'IsUnknown', 'Like', 'Limit', 'Negative', 'Not', 'Partitioning', 'Placeholder', 'Projection', 'Repartition', 'RuntimeConfig', 'SQLOptions', 'ScalarSubquery', 'ScalarUDF', 'ScalarVariable', 'SessionConfig', 'SessionContext', 'SimilarTo', 'Sort', 'Subquery', 'SubqueryAlias', 'TableScan', 'TryCast', 'Window', 'WindowFrame', '__all__', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', '_internal', 'col', 'column', 'common', 'expr', 'lit', 'literal', 'udaf', 'udf']

>>> dir(datafusion.common)
['DFSchema', 'DataType', 'DataTypeMap', 'PythonType', 'SqlFunction', 'SqlSchema', 'SqlStatistics', 'SqlTable', 'SqlType', 'SqlView', '__builtins__', '__cached__', '__dir__', '__doc__', '__file__', '__getattr__', '__loader__', '__name__', '__package__', '__spec__']

```

Personally, instead of exposing just the `_internal` module from PyO3, I would create all these modules and submodules directly from PyO3. I'd use `_datafusion` as the main module, but instead of having a `common.py` file, the `_datafusion.common` submodule would be created directly from PyO3. So, all this magic of `__getattr__` and `__dir__` is not needed. @andygrove is there a reason why this wasn't implemented like this?

Also, I don't think it's a good practice to have everything in the main namespace. I think it's fine that for examples users have to use `datafusion.expr.IsTrue` instead of `datafusion.IsTrue`.