### PR TITLE
Add PyExpr to_variant conversions

### DIFF
--- a/python/datafusion/tests/test_expr.py
+++ b/python/datafusion/tests/test_expr.py
@@ -139,3 +139,31 @@ def test_relational_expr(test_ctx):
     assert df.filter(col("b") != "beta").count() == 2
 
     assert df.filter(col("a") == "beta").count() == 0
+
+
+def test_expr_to_variant():
+    # Taken from https://github.com/apache/datafusion-python/issues/781
+    from datafusion import SessionContext
+    from datafusion.expr import Filter
+
+
+    def traverse_logical_plan(plan):
+        cur_node = plan.to_variant()
+        if isinstance(cur_node, Filter):
+            return cur_node.predicate().to_variant()
+        if hasattr(plan, 'inputs'):
+            for input_plan in plan.inputs():
+                res = traverse_logical_plan(input_plan)
+                if res is not None:
+                    return res
+
+    ctx = SessionContext()
+    data = {'id': [1, 2, 3], 'name': ['Alice', 'Bob', 'Charlie']}
+    ctx.from_pydict(data, name='table1')
+    query = "SELECT * FROM table1 t1 WHERE t1.name IN ('dfa', 'ad', 'dfre', 'vsa')"
+    logical_plan = ctx.sql(query).optimized_logical_plan()
+    variant = traverse_logical_plan(logical_plan)
+    assert variant is not None
+    assert variant.expr().to_variant().qualified_name() == 'table1.name'
+    assert str(variant.list()) == '[Expr(Utf8("dfa")), Expr(Utf8("ad")), Expr(Utf8("dfre")), Expr(Utf8("vsa"))]'
+    assert not variant.negated()

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -158,7 +158,7 @@ impl PyExpr {
             Expr::WindowFunction(_) => todo!(),
             Expr::InList(value) => Ok(in_list::PyInList::from(value.clone()).into_py(py)),
             Expr::Exists(value) => Ok(exists::PyExists::from(value.clone()).into_py(py)),
-            Expr::InSubquery(_) => todo!(),
+            Expr::InSubquery(value) => Ok(in_subquery::PyInSubquery::from(value.clone()).into_py(py)),
             Expr::ScalarSubquery(value) => {
                 Ok(scalar_subquery::PyScalarSubquery::from(value.clone()).into_py(py))
             }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -147,22 +147,28 @@ impl PyExpr {
             Expr::Cast(value) => Ok(cast::PyCast::from(value.clone()).into_py(py)),
             Expr::TryCast(value) => Ok(cast::PyTryCast::from(value.clone()).into_py(py)),
             Expr::Sort(_value) => {
-                todo!("upstream has two different Sort classes, need to figure out which one to use")
+                todo!(
+                    "upstream has two different Sort classes, need to figure out which one to use"
+                )
                 // let py_sort = PySort::from(value.clone());
                 // let py_object = py_sort.into_py(py);
                 // Ok(py_object)
-            },
+            }
             Expr::ScalarFunction(_) => todo!(),
             Expr::WindowFunction(_) => todo!(),
-            Expr::InList(value) => Ok(in_list::PyInList::from(value.clone()).into_py(py))   ,
-            Expr::Exists(_) => todo!(),
+            Expr::InList(value) => Ok(in_list::PyInList::from(value.clone()).into_py(py)),
+            Expr::Exists(value) => Ok(exists::PyExists::from(value.clone()).into_py(py)),
             Expr::InSubquery(_) => todo!(),
-            Expr::ScalarSubquery(value) => Ok(scalar_subquery::PyScalarSubquery::from(value.clone()).into_py(py)),
+            Expr::ScalarSubquery(value) => {
+                Ok(scalar_subquery::PyScalarSubquery::from(value.clone()).into_py(py))
+            }
             Expr::Wildcard { qualifier } => {
                 let _ = qualifier;
                 todo!()
-            },
-            Expr::GroupingSet(value) => Ok(grouping_set::PyGroupingSet::from(value.clone()).into_py(py)),
+            }
+            Expr::GroupingSet(value) => {
+                Ok(grouping_set::PyGroupingSet::from(value.clone()).into_py(py))
+            }
             Expr::Placeholder(_) => todo!(),
             Expr::OuterReferenceColumn(_, _) => todo!(),
             Expr::Unnest(_) => todo!(),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -84,6 +84,7 @@ pub mod scalar_subquery;
 pub mod scalar_variable;
 pub mod signature;
 pub mod sort;
+pub mod sort_expr;
 pub mod subquery;
 pub mod subquery_alias;
 pub mod table_scan;
@@ -146,14 +147,7 @@ impl PyExpr {
             Expr::Case(value) => Ok(case::PyCase::from(value.clone()).into_py(py)),
             Expr::Cast(value) => Ok(cast::PyCast::from(value.clone()).into_py(py)),
             Expr::TryCast(value) => Ok(cast::PyTryCast::from(value.clone()).into_py(py)),
-            Expr::Sort(_value) => {
-                todo!(
-                    "upstream has two different Sort classes, need to figure out which one to use"
-                )
-                // let py_sort = PySort::from(value.clone());
-                // let py_object = py_sort.into_py(py);
-                // Ok(py_object)
-            }
+            Expr::Sort(value) => Ok(sort_expr::PySortExpr::from(value.clone()).into_py(py)),
             Expr::ScalarFunction(_) => todo!(),
             Expr::WindowFunction(_) => todo!(),
             Expr::InList(value) => Ok(in_list::PyInList::from(value.clone()).into_py(py)),
@@ -637,6 +631,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<create_memory_table::PyCreateMemoryTable>()?;
     m.add_class::<create_view::PyCreateView>()?;
     m.add_class::<distinct::PyDistinct>()?;
+    m.add_class::<sort_expr::PySortExpr>()?;
     m.add_class::<subquery_alias::PySubqueryAlias>()?;
     m.add_class::<drop_table::PyDropTable>()?;
     m.add_class::<repartition::PyPartitioning>()?;

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -141,10 +141,31 @@ impl PyExpr {
             Expr::AggregateFunction(expr) => {
                 Ok(PyAggregateFunction::from(expr.clone()).into_py(py))
             }
-            other => Err(py_runtime_err(format!(
-                "Cannot convert this Expr to a Python object: {:?}",
-                other
-            ))),
+            Expr::SimilarTo(value) => Ok(PySimilarTo::from(value.clone()).into_py(py)),
+            Expr::Between(value) => Ok(between::PyBetween::from(value.clone()).into_py(py)),
+            Expr::Case(value) => Ok(case::PyCase::from(value.clone()).into_py(py)),
+            Expr::Cast(value) => Ok(cast::PyCast::from(value.clone()).into_py(py)),
+            Expr::TryCast(value) => Ok(cast::PyTryCast::from(value.clone()).into_py(py)),
+            Expr::Sort(_value) => {
+                todo!("upstream has two different Sort classes, need to figure out which one to use")
+                // let py_sort = PySort::from(value.clone());
+                // let py_object = py_sort.into_py(py);
+                // Ok(py_object)
+            },
+            Expr::ScalarFunction(_) => todo!(),
+            Expr::WindowFunction(_) => todo!(),
+            Expr::InList(_) => todo!(),
+            Expr::Exists(_) => todo!(),
+            Expr::InSubquery(_) => todo!(),
+            Expr::ScalarSubquery(value) => Ok(scalar_subquery::PyScalarSubquery::from(value.clone()).into_py(py)),
+            Expr::Wildcard { qualifier } => {
+                let _ = qualifier;
+                todo!()
+            },
+            Expr::GroupingSet(value) => Ok(grouping_set::PyGroupingSet::from(value.clone()).into_py(py)),
+            Expr::Placeholder(_) => todo!(),
+            Expr::OuterReferenceColumn(_, _) => todo!(),
+            Expr::Unnest(_) => todo!(),
         })
     }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -122,7 +122,7 @@ impl PyExpr {
     /// Return the specific expression
     fn to_variant(&self, py: Python) -> PyResult<PyObject> {
         Python::with_gil(|_| match &self.expr {
-            Expr::Alias(alias) => Ok(PyAlias::new(&alias.expr, &alias.name).into_py(py)),
+            Expr::Alias(alias) => Ok(PyAlias::from(alias.clone()).into_py(py)),
             Expr::Column(col) => Ok(PyColumn::from(col.clone()).into_py(py)),
             Expr::ScalarVariable(data_type, variables) => {
                 Ok(PyScalarVariable::new(data_type, variables).into_py(py))

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -154,7 +154,7 @@ impl PyExpr {
             },
             Expr::ScalarFunction(_) => todo!(),
             Expr::WindowFunction(_) => todo!(),
-            Expr::InList(_) => todo!(),
+            Expr::InList(value) => Ok(in_list::PyInList::from(value.clone()).into_py(py))   ,
             Expr::Exists(_) => todo!(),
             Expr::InSubquery(_) => todo!(),
             Expr::ScalarSubquery(value) => Ok(scalar_subquery::PyScalarSubquery::from(value.clone()).into_py(py)),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -158,7 +158,9 @@ impl PyExpr {
             Expr::WindowFunction(_) => todo!(),
             Expr::InList(value) => Ok(in_list::PyInList::from(value.clone()).into_py(py)),
             Expr::Exists(value) => Ok(exists::PyExists::from(value.clone()).into_py(py)),
-            Expr::InSubquery(value) => Ok(in_subquery::PyInSubquery::from(value.clone()).into_py(py)),
+            Expr::InSubquery(value) => {
+                Ok(in_subquery::PyInSubquery::from(value.clone()).into_py(py))
+            }
             Expr::ScalarSubquery(value) => {
                 Ok(scalar_subquery::PyScalarSubquery::from(value.clone()).into_py(py))
             }
@@ -169,7 +171,9 @@ impl PyExpr {
             Expr::GroupingSet(value) => {
                 Ok(grouping_set::PyGroupingSet::from(value.clone()).into_py(py))
             }
-            Expr::Placeholder(_) => todo!(),
+            Expr::Placeholder(value) => {
+                Ok(placeholder::PyPlaceholder::from(value.clone()).into_py(py))
+            }
             Expr::OuterReferenceColumn(_, _) => todo!(),
             Expr::Unnest(_) => todo!(),
         })

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -90,6 +90,7 @@ pub mod subquery_alias;
 pub mod table_scan;
 pub mod union;
 pub mod unnest;
+pub mod unnest_expr;
 pub mod window;
 
 /// A PyExpr that can be used on a DataFrame
@@ -169,7 +170,7 @@ impl PyExpr {
                 Ok(placeholder::PyPlaceholder::from(value.clone()).into_py(py))
             }
             Expr::OuterReferenceColumn(_, _) => todo!(),
-            Expr::Unnest(_) => todo!(),
+            Expr::Unnest(value) => Ok(unnest_expr::PyUnnestExpr::from(value.clone()).into_py(py)),
         })
     }
 
@@ -624,6 +625,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<cross_join::PyCrossJoin>()?;
     m.add_class::<union::PyUnion>()?;
     m.add_class::<unnest::PyUnnest>()?;
+    m.add_class::<unnest_expr::PyUnnestExpr>()?;
     m.add_class::<extension::PyExtension>()?;
     m.add_class::<filter::PyFilter>()?;
     m.add_class::<projection::PyProjection>()?;

--- a/src/expr/alias.rs
+++ b/src/expr/alias.rs
@@ -19,13 +19,24 @@ use crate::expr::PyExpr;
 use pyo3::prelude::*;
 use std::fmt::{self, Display, Formatter};
 
-use datafusion_expr::Expr;
+use datafusion_expr::expr::Alias;
 
 #[pyclass(name = "Alias", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyAlias {
-    expr: PyExpr,
-    alias_name: String,
+    alias: Alias,
+}
+
+impl From<Alias> for PyAlias {
+    fn from(alias: Alias) -> Self {
+        Self { alias }
+    }
+}
+
+impl From<PyAlias> for Alias {
+    fn from(py_alias: PyAlias) -> Self {
+        py_alias.alias
+    }
 }
 
 impl Display for PyAlias {
@@ -35,17 +46,8 @@ impl Display for PyAlias {
             "Alias
             \nExpr: `{:?}`
             \nAlias Name: `{}`",
-            &self.expr, &self.alias_name
+            &self.alias.expr, &self.alias.name
         )
-    }
-}
-
-impl PyAlias {
-    pub fn new(expr: &Expr, alias_name: &String) -> Self {
-        Self {
-            expr: expr.clone().into(),
-            alias_name: alias_name.to_owned(),
-        }
     }
 }
 
@@ -53,11 +55,11 @@ impl PyAlias {
 impl PyAlias {
     /// Retrieve the "name" of the alias
     fn alias(&self) -> PyResult<String> {
-        Ok(self.alias_name.clone())
+        Ok(self.alias.name.clone())
     }
 
     fn expr(&self) -> PyResult<PyExpr> {
-        Ok(self.expr.clone())
+        Ok((*self.alias.expr.clone()).into())
     }
 
     /// Get a String representation of this column

--- a/src/expr/exists.rs
+++ b/src/expr/exists.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion_expr::Subquery;
+use datafusion_expr::expr::Exists;
 use pyo3::prelude::*;
 
 use super::subquery::PySubquery;
@@ -23,23 +23,22 @@ use super::subquery::PySubquery;
 #[pyclass(name = "Exists", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyExists {
-    subquery: Subquery,
-    negated: bool,
+    exists: Exists,
 }
 
-impl PyExists {
-    pub fn new(subquery: Subquery, negated: bool) -> Self {
-        Self { subquery, negated }
+impl From<Exists> for PyExists {
+    fn from(exists: Exists) -> Self {
+        PyExists { exists }
     }
 }
 
 #[pymethods]
 impl PyExists {
     fn subquery(&self) -> PySubquery {
-        self.subquery.clone().into()
+        self.exists.subquery.clone().into()
     }
 
     fn negated(&self) -> bool {
-        self.negated
+        self.exists.negated
     }
 }

--- a/src/expr/in_list.rs
+++ b/src/expr/in_list.rs
@@ -16,38 +16,32 @@
 // under the License.
 
 use crate::expr::PyExpr;
-use datafusion_expr::Expr;
+use datafusion_expr::expr::InList;
 use pyo3::prelude::*;
 
 #[pyclass(name = "InList", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyInList {
-    expr: Box<Expr>,
-    list: Vec<Expr>,
-    negated: bool,
+    in_list: InList,
 }
 
-impl PyInList {
-    pub fn new(expr: Box<Expr>, list: Vec<Expr>, negated: bool) -> Self {
-        Self {
-            expr,
-            list,
-            negated,
-        }
+impl From<InList> for PyInList {
+    fn from(in_list: InList) -> Self {
+        PyInList { in_list }
     }
 }
 
 #[pymethods]
 impl PyInList {
     fn expr(&self) -> PyExpr {
-        (*self.expr).clone().into()
+        (*self.in_list.expr).clone().into()
     }
 
     fn list(&self) -> Vec<PyExpr> {
-        self.list.iter().map(|e| e.clone().into()).collect()
+        self.in_list.list.iter().map(|e| e.clone().into()).collect()
     }
 
     fn negated(&self) -> bool {
-        self.negated
+        self.in_list.negated
     }
 }

--- a/src/expr/in_subquery.rs
+++ b/src/expr/in_subquery.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion_expr::{Expr, Subquery};
+use datafusion_expr::expr::InSubquery;
 use pyo3::prelude::*;
 
 use super::{subquery::PySubquery, PyExpr};
@@ -23,32 +23,26 @@ use super::{subquery::PySubquery, PyExpr};
 #[pyclass(name = "InSubquery", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyInSubquery {
-    expr: Box<Expr>,
-    subquery: Subquery,
-    negated: bool,
+    in_subquery: InSubquery,
 }
 
-impl PyInSubquery {
-    pub fn new(expr: Box<Expr>, subquery: Subquery, negated: bool) -> Self {
-        Self {
-            expr,
-            subquery,
-            negated,
-        }
+impl From<InSubquery> for PyInSubquery {
+    fn from(in_subquery: InSubquery) -> Self {
+        PyInSubquery { in_subquery }
     }
 }
 
 #[pymethods]
 impl PyInSubquery {
     fn expr(&self) -> PyExpr {
-        (*self.expr).clone().into()
+        (*self.in_subquery.expr).clone().into()
     }
 
     fn subquery(&self) -> PySubquery {
-        self.subquery.clone().into()
+        self.in_subquery.subquery.clone().into()
     }
 
     fn negated(&self) -> bool {
-        self.negated
+        self.in_subquery.negated
     }
 }

--- a/src/expr/placeholder.rs
+++ b/src/expr/placeholder.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion::arrow::datatypes::DataType;
+use datafusion_expr::expr::Placeholder;
 use pyo3::prelude::*;
 
 use crate::common::data_type::PyDataType;
@@ -23,26 +23,25 @@ use crate::common::data_type::PyDataType;
 #[pyclass(name = "Placeholder", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyPlaceholder {
-    id: String,
-    data_type: Option<DataType>,
+    placeholder: Placeholder,
 }
 
-impl PyPlaceholder {
-    pub fn new(id: String, data_type: DataType) -> Self {
-        Self {
-            id,
-            data_type: Some(data_type),
-        }
+impl From<Placeholder> for PyPlaceholder {
+    fn from(placeholder: Placeholder) -> Self {
+        PyPlaceholder { placeholder }
     }
 }
 
 #[pymethods]
 impl PyPlaceholder {
     fn id(&self) -> String {
-        self.id.clone()
+        self.placeholder.id.clone()
     }
 
     fn data_type(&self) -> Option<PyDataType> {
-        self.data_type.as_ref().map(|e| e.clone().into())
+        self.placeholder
+            .data_type
+            .as_ref()
+            .map(|e| e.clone().into())
     }
 }

--- a/src/expr/sort_expr.rs
+++ b/src/expr/sort_expr.rs
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::expr::PyExpr;
+use datafusion_expr::SortExpr;
+use pyo3::prelude::*;
+use std::fmt::{self, Display, Formatter};
+
+#[pyclass(name = "SortExpr", module = "datafusion.expr", subclass)]
+#[derive(Clone)]
+pub struct PySortExpr {
+    sort: SortExpr,
+}
+
+impl From<PySortExpr> for SortExpr {
+    fn from(sort: PySortExpr) -> Self {
+        sort.sort
+    }
+}
+
+impl From<SortExpr> for PySortExpr {
+    fn from(sort: SortExpr) -> PySortExpr {
+        PySortExpr { sort }
+    }
+}
+
+impl Display for PySortExpr {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Sort
+            Expr: {:?}
+            Asc: {:?}
+            NullsFirst: {:?}",
+            &self.sort.expr, &self.sort.asc, &self.sort.nulls_first
+        )
+    }
+}
+
+#[pymethods]
+impl PySortExpr {
+    fn expr(&self) -> PyResult<PyExpr> {
+        Ok((*self.sort.expr).clone().into())
+    }
+
+    fn ascending(&self) -> PyResult<bool> {
+        Ok(self.sort.asc)
+    }
+
+    fn nulls_first(&self) -> PyResult<bool> {
+        Ok(self.sort.nulls_first)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{}", self)
+    }
+}

--- a/src/expr/unnest_expr.rs
+++ b/src/expr/unnest_expr.rs
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion_expr::expr::Unnest;
+use pyo3::prelude::*;
+use std::fmt::{self, Display, Formatter};
+
+use super::PyExpr;
+
+#[pyclass(name = "UnnestExpr", module = "datafusion.expr", subclass)]
+#[derive(Clone)]
+pub struct PyUnnestExpr {
+    unnest: Unnest,
+}
+
+impl From<Unnest> for PyUnnestExpr {
+    fn from(unnest: Unnest) -> PyUnnestExpr {
+        PyUnnestExpr { unnest }
+    }
+}
+
+impl From<PyUnnestExpr> for Unnest {
+    fn from(unnest: PyUnnestExpr) -> Self {
+        unnest.unnest
+    }
+}
+
+impl Display for PyUnnestExpr {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Unnest
+            Expr: {:?}",
+            &self.unnest.expr,
+        )
+    }
+}
+
+#[pymethods]
+impl PyUnnestExpr {
+    /// Retrieves the expression that is being unnested
+    fn expr(&self) -> PyResult<PyExpr> {
+        Ok((*self.unnest.expr).clone().into())
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("UnnestExpr({})", self))
+    }
+
+    fn __name__(&self) -> PyResult<String> {
+        Ok("UnnestExpr".to_string())
+    }
+}

--- a/src/sql/logical.rs
+++ b/src/sql/logical.rs
@@ -17,6 +17,7 @@
 
 use std::sync::Arc;
 
+use crate::errors::py_unsupported_variant_err;
 use crate::expr::aggregate::PyAggregate;
 use crate::expr::analyze::PyAnalyze;
 use crate::expr::cross_join::PyCrossJoin;
@@ -80,16 +81,19 @@ impl PyLogicalPlan {
             LogicalPlan::SubqueryAlias(plan) => PySubqueryAlias::from(plan.clone()).to_variant(py),
             LogicalPlan::Unnest(plan) => PyUnnest::from(plan.clone()).to_variant(py),
             LogicalPlan::Window(plan) => PyWindow::from(plan.clone()).to_variant(py),
-            LogicalPlan::Repartition(_) => todo!(),
-            LogicalPlan::Union(_) => todo!(),
-            LogicalPlan::Statement(_) => todo!(),
-            LogicalPlan::Values(_) => todo!(),
-            LogicalPlan::Prepare(_) => todo!(),
-            LogicalPlan::Dml(_) => todo!(),
-            LogicalPlan::Ddl(_) => todo!(),
-            LogicalPlan::Copy(_) => todo!(),
-            LogicalPlan::DescribeTable(_) => todo!(),
-            LogicalPlan::RecursiveQuery(_) => todo!(),
+            LogicalPlan::Repartition(_)
+            | LogicalPlan::Union(_)
+            | LogicalPlan::Statement(_)
+            | LogicalPlan::Values(_)
+            | LogicalPlan::Prepare(_)
+            | LogicalPlan::Dml(_)
+            | LogicalPlan::Ddl(_)
+            | LogicalPlan::Copy(_)
+            | LogicalPlan::DescribeTable(_)
+            | LogicalPlan::RecursiveQuery(_) => Err(py_unsupported_variant_err(format!(
+                "Conversion of variant not implemented: {:?}",
+                self.plan
+            ))),
         }
     }
 

--- a/src/sql/logical.rs
+++ b/src/sql/logical.rs
@@ -81,10 +81,16 @@ impl PyLogicalPlan {
             LogicalPlan::SubqueryAlias(plan) => PySubqueryAlias::from(plan.clone()).to_variant(py),
             LogicalPlan::Unnest(plan) => PyUnnest::from(plan.clone()).to_variant(py),
             LogicalPlan::Window(plan) => PyWindow::from(plan.clone()).to_variant(py),
-            other => Err(py_unsupported_variant_err(format!(
-                "Cannot convert this plan to a LogicalNode: {:?}",
-                other
-            ))),
+            LogicalPlan::Repartition(_) => todo!(),
+            LogicalPlan::Union(_) => todo!(),
+            LogicalPlan::Statement(_) => todo!(),
+            LogicalPlan::Values(_) => todo!(),
+            LogicalPlan::Prepare(_) => todo!(),
+            LogicalPlan::Dml(_) => todo!(),
+            LogicalPlan::Ddl(_) => todo!(),
+            LogicalPlan::Copy(_) => todo!(),
+            LogicalPlan::DescribeTable(_) => todo!(),
+            LogicalPlan::RecursiveQuery(_) => todo!(),
         }
     }
 

--- a/src/sql/logical.rs
+++ b/src/sql/logical.rs
@@ -17,7 +17,6 @@
 
 use std::sync::Arc;
 
-use crate::errors::py_unsupported_variant_err;
 use crate::expr::aggregate::PyAggregate;
 use crate::expr::analyze::PyAnalyze;
 use crate::expr::cross_join::PyCrossJoin;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #781.

 # Rationale for this change
The user bug report filed

> When a SQL query contains a InList Expr, I can't get the InList object through Expr.to_variant().

In fixing this bug, I found that upstream datafusion has added explicit structs for many of the variants, so I also updated the datafusion-python variants for those.

Lastly, `datafusion-python` was incorrectly returning the `logical_plan::Sort` instead of the `expr::Sort` as the variant for the `Expr::Sort`.

# Changes

## These `Py-Variants` now wrap the upstream variant structs.

- `PyAlias` now wraps `datafusion_expr::expr::Alias`
- `PyExists` now wraps `datafusion_expr::expr::Exists`
- `PyInList` now wraps `datafusion_expr::expr::PyInList`
- `PyInSubquery` now wraps `datafusion_expr::expr::InSubquery` 
- `PyPlaceholder` now wraps `datafusion_expr::expr::Placeholder`
 
## Disambiguating `datafusion_expr::logical_plan::*` and `datafusion_expr::expr::*` variants

`PyExpr::to_variant` was incorrectly returning variants `datafusion_expr::logical_plan::Sort` and `datafusion_expr::logical_plan::Unnest`.

- `PySortExpr` was created to wrap [datafusion_expr::expr::Sort](https://docs.rs/datafusion-expr/40.0.0/datafusion_expr/expr/struct.Sort.html)
- `PyUnnestExpr` was created to wrap [datafusion_expr::expr::Unnest](https://docs.rs/datafusion-expr/40.0.0/datafusion_expr/expr/struct.Unnest.html)

**NOTE** I chose `PySortExpr` because that is how `datafusion_expr` [re-exports expr::Sort as SortExpr](https://docs.rs/datafusion-expr/40.0.0/datafusion_expr/index.html#reexport.SortExpr)

## `PyExpr::to_variant` additionally implemented for

- `SimilarTo`
- `Between`
- `Case`
- `Cast`
- `TryCast`
- `InList`
- `Exists`
- `InSubquery`
- `ScalarSubquery`
- `GroupingSet`
- `Placeholder`

