### PR TITLE
UDAF process all state variables

### DIFF
--- a/docs/source/user-guide/common-operations/udf-and-udfa.rst
+++ b/docs/source/user-guide/common-operations/udf-and-udfa.rst
@@ -50,6 +50,7 @@ Additionally the :py:func:`~datafusion.udf.AggregateUDF.udaf` function allows yo
     import pyarrow.compute
     import datafusion
     from datafusion import col, udaf, Accumulator
+    from typing import List
 
     class MyAccumulator(Accumulator):
         """
@@ -62,9 +63,9 @@ Additionally the :py:func:`~datafusion.udf.AggregateUDF.udaf` function allows yo
             # not nice since pyarrow scalars can't be summed yet. This breaks on `None`
             self._sum = pyarrow.scalar(self._sum.as_py() + pyarrow.compute.sum(values).as_py())
 
-        def merge(self, states: pyarrow.Array) -> None:
+        def merge(self, states: List[pyarrow.Array]) -> None:
             # not nice since pyarrow scalars can't be summed yet. This breaks on `None`
-            self._sum = pyarrow.scalar(self._sum.as_py() + pyarrow.compute.sum(states).as_py())
+            self._sum = pyarrow.scalar(self._sum.as_py() + pyarrow.compute.sum(states[0]).as_py())
 
         def state(self) -> pyarrow.Array:
             return pyarrow.array([self._sum.as_py()])

--- a/python/datafusion/tests/test_udaf.py
+++ b/python/datafusion/tests/test_udaf.py
@@ -38,10 +38,10 @@ class Summarize(Accumulator):
         # This breaks on `None`
         self._sum = pa.scalar(self._sum.as_py() + pc.sum(values).as_py())
 
-    def merge(self, states: pa.Array) -> None:
+    def merge(self, states: List[pa.Array]) -> None:
         # Not nice since pyarrow scalars can't be summed yet.
         # This breaks on `None`
-        self._sum = pa.scalar(self._sum.as_py() + pc.sum(states).as_py())
+        self._sum = pa.scalar(self._sum.as_py() + pc.sum(states[0]).as_py())
 
     def evaluate(self) -> pa.Scalar:
         return self._sum

--- a/python/datafusion/udf.py
+++ b/python/datafusion/udf.py
@@ -157,7 +157,7 @@ class Accumulator(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def merge(self, states: pyarrow.Array) -> None:
+    def merge(self, states: List[pyarrow.Array]) -> None:
         """Merge a set of states."""
         pass
 

--- a/src/udaf.rs
+++ b/src/udaf.rs
@@ -72,18 +72,29 @@ impl Accumulator for RustAccumulator {
 
     fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
         Python::with_gil(|py| {
-            let state = &states[0];
+            // let state = &states[0];
 
-            // 1. cast states to Pyarrow array
-            let state = state
-                .into_data()
-                .to_pyarrow(py)
-                .map_err(|e| DataFusionError::Execution(format!("{e}")))?;
+            // // 1. cast states to Pyarrow array
+            // let state = state
+            //     .into_data()
+            //     .to_pyarrow(py)
+            //     .map_err(|e| DataFusionError::Execution(format!("{e}")))?;
+            let py_states: Result<Vec<PyObject>> = states
+                .iter()
+                .map(|state| {
+                    state
+                        .into_data()
+                        .to_pyarrow(py)
+                        .map_err(|e| DataFusionError::Execution(format!("{e}")))
+                })
+                .collect();
+
+            // let py_states = PyTuple::new_bound(py, py_states?.iter());
 
             // 2. call merge
             self.accum
                 .bind(py)
-                .call_method1("merge", (state,))
+                .call_method1("merge", (py_states?,))
                 .map_err(|e| DataFusionError::Execution(format!("{e}")))?;
 
             Ok(())

--- a/src/udaf.rs
+++ b/src/udaf.rs
@@ -72,13 +72,7 @@ impl Accumulator for RustAccumulator {
 
     fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
         Python::with_gil(|py| {
-            // let state = &states[0];
-
-            // // 1. cast states to Pyarrow array
-            // let state = state
-            //     .into_data()
-            //     .to_pyarrow(py)
-            //     .map_err(|e| DataFusionError::Execution(format!("{e}")))?;
+            // // 1. cast states to Pyarrow arrays
             let py_states: Result<Vec<PyObject>> = states
                 .iter()
                 .map(|state| {
@@ -88,8 +82,6 @@ impl Accumulator for RustAccumulator {
                         .map_err(|e| DataFusionError::Execution(format!("{e}")))
                 })
                 .collect();
-
-            // let py_states = PyTuple::new_bound(py, py_states?.iter());
 
             // 2. call merge
             self.accum


### PR DESCRIPTION
# Which issue does this PR close?

Closes #797 

 # Rationale for this change

Currently only the first state variable in a user defined aggregate function is passed to the `merge` stage.

# What changes are included in this PR?

Passes all state variables to the `merge` call.

# Are there any user-facing changes?

Yes, any user of udaf will need to change their merge stage to use `states[0]` instead of `states`. 