### PR TITLE
Add typing-extensions dependency to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifier = [
 ]
 dependencies = [
     "pyarrow>=11.0.0",
-    "typing-extensions",
+    "typing-extensions;python_version<'3.13'",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ classifier = [
 ]
 dependencies = [
     "pyarrow>=11.0.0",
+    "typing-extensions",
 ]
 
 [project.urls]


### PR DESCRIPTION
# Which issue does this PR close?

This is related to https://github.com/apache/datafusion-python/issues/804

 # Rationale for this change

#750 introduced wrapper classes that include the `@deprecated` annotation on a few functions. If `typing-extensions` is not installed, `import datafusion` will fail.

# What changes are included in this PR?

Adds typing extensions to the pyproject so that pip will ensure it is installed.

# Are there any user-facing changes?

None