### PR TITLE
Add Window Functions for use with function builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ apache-rat-*.jar
 CHANGELOG.md.bak
 
 docs/mdbook/book
+
+.pyo3_build_config
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target
 /docs/temp
 /docs/build
 .DS_Store
+.vscode
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/source/user-guide/common-operations/aggregations.rst
+++ b/docs/source/user-guide/common-operations/aggregations.rst
@@ -15,6 +15,8 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
+.. _aggregation:
+
 Aggregation
 ============
 

--- a/docs/source/user-guide/common-operations/windows.rst
+++ b/docs/source/user-guide/common-operations/windows.rst
@@ -15,13 +15,16 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
+.. _window_functions:
+
 Window Functions
 ================
 
-In this section you will learn about window functions. A window function utilizes values from one or multiple rows to
-produce a result for each individual row, unlike an aggregate function that provides a single value for multiple rows.
+In this section you will learn about window functions. A window function utilizes values from one or
+multiple rows to produce a result for each individual row, unlike an aggregate function that
+provides a single value for multiple rows.
 
-The functionality of window functions in DataFusion is supported by the dedicated :py:func:`~datafusion.functions.window` function.
+The window functions are availble in the :py:mod:`~datafusion.functions` module.
 
 We'll use the pokemon dataset (from Ritchie Vink) in the following examples.
 
@@ -40,17 +43,18 @@ We'll use the pokemon dataset (from Ritchie Vink) in the following examples.
     ctx = SessionContext()
     df = ctx.read_csv("pokemon.csv")
 
-Here is an example that shows how to compare each pokemons’s attack power with the average attack power in its ``"Type 1"``
+Here is an example that shows how to compare each pokemons’s attack power with the average attack
+power in its ``"Type 1"``
 
 .. ipython:: python
 
     df.select(
         col('"Name"'),
         col('"Attack"'),
-        f.alias(
-            f.window("avg", [col('"Attack"')], partition_by=[col('"Type 1"')]),
-            "Average Attack",
-        )
+        #f.alias(
+        #    f.window("avg", [col('"Attack"')], partition_by=[col('"Type 1"')]),
+        #    "Average Attack",
+        #)
     )
 
 You can also control the order in which rows are processed by window functions by providing
@@ -61,15 +65,15 @@ a list of ``order_by`` functions for the ``order_by`` parameter.
     df.select(
         col('"Name"'),
         col('"Attack"'),
-        f.alias(
-            f.window(
-                "rank",
-                [],
-                partition_by=[col('"Type 1"')],
-                order_by=[f.order_by(col('"Attack"'))],
-            ),
-            "rank",
-        ),
+        #f.alias(
+        #    f.window(
+        #        "rank",
+        #        [],
+        #        partition_by=[col('"Type 1"')],
+        #        order_by=[f.order_by(col('"Attack"'))],
+        #    ),
+        #    "rank",
+        #),
     )
 
 The possible window functions are:

--- a/docs/source/user-guide/common-operations/windows.rst
+++ b/docs/source/user-guide/common-operations/windows.rst
@@ -43,21 +43,21 @@ We'll use the pokemon dataset (from Ritchie Vink) in the following examples.
     ctx = SessionContext()
     df = ctx.read_csv("pokemon.csv")
 
-Here is an example that shows how to compare each pokemons’s attack power with the average attack
-power in its ``"Type 1"``
+Here is an example that shows how you can compare each pokemon's speed to the speed of the
+previous row in the DataFrame.
 
 .. ipython:: python
 
     df.select(
         col('"Name"'),
-        col('"Attack"'),
-        #f.alias(
-        #    f.window("avg", [col('"Attack"')], partition_by=[col('"Type 1"')]),
-        #    "Average Attack",
-        #)
+        col('"Speed"'),
+        f.lag(col('"Speed"')).alias("Previous Speed")
     )
 
-You can also control the order in which rows are processed by window functions by providing
+Setting Parameters
+------------------
+
+You can control the order in which rows are processed by window functions by providing
 a list of ``order_by`` functions for the ``order_by`` parameter.
 
 .. ipython:: python
@@ -65,33 +65,64 @@ a list of ``order_by`` functions for the ``order_by`` parameter.
     df.select(
         col('"Name"'),
         col('"Attack"'),
-        #f.alias(
-        #    f.window(
-        #        "rank",
-        #        [],
-        #        partition_by=[col('"Type 1"')],
-        #        order_by=[f.order_by(col('"Attack"'))],
-        #    ),
-        #    "rank",
-        #),
+        col('"Type 1"'),
+        f.rank()
+            .partition_by(col('"Type 1"'))
+            .order_by(col('"Attack"').sort(ascending=True))
+            .build()
+            .alias("rank"),
+    ).sort(col('"Type 1"').sort(), col('"Attack"').sort())
+
+Window Functions can be configured using a builder approach to set a few parameters.
+To create a builder you simply need to call any one of these functions
+
+- :py:func:`datafusion.expr.Expr.order_by` to set the window ordering.
+- :py:func:`datafusion.expr.Expr.null_treatment` to set how ``null`` values should be handled.
+- :py:func:`datafusion.expr.Expr.partition_by` to set the partitions for processing.
+- :py:func:`datafusion.expr.Expr.window_frame` to set boundary of operation.
+
+After these parameters are set, you must call ``build()`` on the resultant object to get an
+expression as shown in the example above.
+
+Aggregate Functions
+-------------------
+
+You can use any  :ref:`Aggregation Function<aggregation>` as a window function. Currently
+aggregate functions must use the deprecated
+:py:func:`datafusion.functions.window` API but this should be resolved in
+DataFusion 42.0 (`Issue Link <https://github.com/apache/datafusion-python/issues/833>`_). Here
+is an example that shows how to compare each pokemons’s attack power with the average attack
+power in its ``"Type 1"`` using the :py:func:`datafusion.functions.avg` function.
+
+.. ipython:: python
+    :okwarning:
+
+    df.select(
+        col('"Name"'),
+        col('"Attack"'),
+        col('"Type 1"'),
+        f.window("avg", [col('"Attack"')])
+            .partition_by(col('"Type 1"'))
+            .build()
+            .alias("Average Attack"),
     )
+
+Available Functions
+-------------------
 
 The possible window functions are:
 
 1. Rank Functions
-    - rank
-    - dense_rank
-    - row_number
-    - ntile
+    - :py:func:`datafusion.functions.rank`
+    - :py:func:`datafusion.functions.dense_rank`
+    - :py:func:`datafusion.functions.ntile`
+    - :py:func:`datafusion.functions.row_number`
 
 2. Analytical Functions
-    - cume_dist
-    - percent_rank
-    - lag
-    - lead
-    - first_value
-    - last_value
-    - nth_value
+    - :py:func:`datafusion.functions.cume_dist`
+    - :py:func:`datafusion.functions.percent_rank`
+    - :py:func:`datafusion.functions.lag`
+    - :py:func:`datafusion.functions.lead`
 
 3. Aggregate Functions
-    - All aggregate functions can be used as window functions.
+    - All :ref:`Aggregation Functions<aggregation>` can be used as window functions.

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -123,11 +123,10 @@ class DataFrame:
             df = df.select("a", col("b"), col("a").alias("alternate_a"))
 
         """
-        exprs = [
-            arg.expr if isinstance(arg, Expr) else Expr.column(arg).expr
-            for arg in exprs
+        exprs_internal = [
+            Expr.column(arg).expr if isinstance(arg, str) else arg.expr for arg in exprs
         ]
-        return DataFrame(self.df.select(*exprs))
+        return DataFrame(self.df.select(*exprs_internal))
 
     def filter(self, *predicates: Expr) -> DataFrame:
         """Return a DataFrame for which ``predicate`` evaluates to ``True``.

--- a/python/datafusion/expr.py
+++ b/python/datafusion/expr.py
@@ -463,7 +463,7 @@ class Expr:
         set parameters for either window or aggregate functions. If used on any other
         type of expression, an error will be generated when ``build()`` is called.
         """
-        return ExprFuncBuilder(self.expr.window_frame(window_frame))
+        return ExprFuncBuilder(self.expr.window_frame(window_frame.window_frame))
 
 
 class ExprFuncBuilder:
@@ -498,7 +498,7 @@ class ExprFuncBuilder:
 
     def window_frame(self, window_frame: WindowFrame) -> ExprFuncBuilder:
         """Set window frame for window functions."""
-        return ExprFuncBuilder(self.builder.window_frame(window_frame))
+        return ExprFuncBuilder(self.builder.window_frame(window_frame.window_frame))
 
     def build(self) -> Expr:
         """Create an expression from a Function Builder."""

--- a/python/datafusion/expr.py
+++ b/python/datafusion/expr.py
@@ -355,6 +355,10 @@ class Expr:
         """Returns ``True`` if this expression is null."""
         return Expr(self.expr.is_null())
 
+    def is_not_null(self) -> Expr:
+        """Returns ``True`` if this expression is not null."""
+        return Expr(self.expr.is_not_null())
+
     def cast(self, to: pa.DataType[Any]) -> Expr:
         """Cast to a new data type."""
         return Expr(self.expr.cast(to))
@@ -404,6 +408,17 @@ class Expr:
     def column_name(self, plan: LogicalPlan) -> str:
         """Compute the output column name based on the provided logical plan."""
         return self.expr.column_name(plan)
+
+    def order_by(self, *exprs: Expr) -> ExprFuncBuilder:
+        return ExprFuncBuilder(self.expr.order_by(list(e.expr for e in exprs)))
+
+
+class ExprFuncBuilder:
+    def __init__(self, builder: expr_internal.ExprFuncBuilder):
+        self.builder = builder
+
+    def build(self) -> Expr:
+        return Expr(self.builder.build())
 
 
 class WindowFrame:

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -1712,23 +1712,13 @@ def first_value(
     )
 
 
-def last_value(
-    arg: Expr,
-    distinct: bool = False,
-    filter: bool = None,
-    order_by: Expr | None = None,
-    null_treatment: common.NullTreatment | None = None,
-) -> Expr:
-    """Returns the last value in a group of values."""
-    return Expr(
-        f.last_value(
-            arg.expr,
-            distinct=distinct,
-            filter=filter,
-            order_by=order_by,
-            null_treatment=null_treatment,
-        )
-    )
+def last_value(arg: Expr) -> Expr:
+    """Returns the last value in a group of values.
+
+    To set parameters on this expression, use ``.order_by()``, ``.distinct()``,
+    ``.filter()``, or ``.null_treatment()``.
+    """
+    return Expr(f.last_value(arg.expr))
 
 
 def bit_and(arg: Expr, distinct: bool = False) -> Expr:
@@ -1757,4 +1747,5 @@ def bool_or(arg: Expr, distinct: bool = False) -> Expr:
 
 
 def lead(arg: Expr, shift_offset: int = 1, default_value: pa.Scalar | None = None):
+    """Create a lead window function."""
     return Expr(f.lead(arg.expr, shift_offset, default_value))

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -28,7 +28,6 @@ from datafusion.expr import CaseBuilder, Expr, WindowFrame
 from datafusion.context import SessionContext
 
 from typing import Any, Optional
-from typing_extensions import deprecated
 
 import pyarrow as pa
 

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -253,6 +253,7 @@ __all__ = [
     "when",
     "window",
     "lead",
+    "lag",
 ]
 
 
@@ -1771,3 +1772,22 @@ def lead(arg: Expr, shift_offset: int = 1, default_value: Optional[Any] = None) 
         default_value = pa.scalar(default_value)
 
     return Expr(f.lead(arg.expr, shift_offset, default_value))
+
+
+def lag(arg: Expr, shift_offset: int = 1, default_value: Optional[Any] = None) -> Expr:
+    """Create a lag window function.
+
+    Lag operation will return the argument that is in the previous shift_offset-th row
+    in the partition. For example ``lag(col("b"), shift_offset=3, default_value=5)``
+    will return the 3rd previous value in column ``b``. At the beginnig of the
+    partition, where no values can be returned it will return the default value of 5.
+
+    Args:
+        arg: Value to return
+        shift_offset: Number of rows before the current row.
+        default_value: Value to return if shift_offet row does not exist.
+    """
+    if not isinstance(default_value, pa.Scalar):
+        default_value = pa.scalar(default_value)
+
+    return Expr(f.lag(arg.expr, shift_offset, default_value))

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -1710,29 +1710,47 @@ def regr_syy(y: Expr, x: Expr, distinct: bool = False) -> Expr:
 def first_value(
     arg: Expr,
     distinct: bool = False,
-    filter: bool = None,
-    order_by: Expr | None = None,
-    null_treatment: common.NullTreatment | None = None,
+    filter: Optional[bool] = None,
+    order_by: Optional[list[Expr]] = None,
+    null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Returns the first value in a group of values."""
+    order_by_cols = [e.expr for e in order_by] if order_by is not None else None
+
     return Expr(
         f.first_value(
             arg.expr,
             distinct=distinct,
             filter=filter,
-            order_by=order_by,
+            order_by=order_by_cols,
             null_treatment=null_treatment,
         )
     )
 
 
-def last_value(arg: Expr) -> Expr:
+def last_value(
+    arg: Expr,
+    distinct: bool = False,
+    filter: Optional[bool] = None,
+    order_by: Optional[list[Expr]] = None,
+    null_treatment: Optional[common.NullTreatment] = None,
+) -> Expr:
     """Returns the last value in a group of values.
 
     To set parameters on this expression, use ``.order_by()``, ``.distinct()``,
     ``.filter()``, or ``.null_treatment()``.
     """
-    return Expr(f.last_value(arg.expr))
+    order_by_cols = [e.expr for e in order_by] if order_by is not None else None
+
+    return Expr(
+        f.last_value(
+            arg.expr,
+            distinct=distinct,
+            filter=filter,
+            order_by=order_by_cols,
+            null_treatment=null_treatment,
+        )
+    )
 
 
 def bit_and(arg: Expr, distinct: bool = False) -> Expr:

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -259,6 +259,7 @@ __all__ = [
     "rank",
     "dense_rank",
     "percent_rank",
+    "cume_dist",
 ]
 
 
@@ -1865,28 +1866,54 @@ def dense_rank() -> Expr:
     To set window function parameters use the window builder approach described in the
     ref:`_window_functions` online documentation.
     """
-    return Expr(f.rank())
+    return Expr(f.dense_rank())
 
 
 def percent_rank() -> Expr:
     """Create a percent_rank window function.
 
     This window function is similar to :py:func:`rank` except that the returned values
-    will be consecutive. Here is an example of a dataframe with a window ordered by
-    descending ``points`` and the associated dense rank.
+    are the percentage from 0.0 to 1.0 from first to last. Here is an example of a
+    dataframe with a window ordered by descending ``points`` and the associated percent
+    rank.
 
     ```
-    +--------+------+
-    | points | rank |
-    +--------+------+
-    | 100    | 1    |
-    | 100    | 1    |
-    | 50     | 2    |
-    | 25     | 3    |
-    +--------+------+
+    +--------+--------------+
+    | points | percent_rank |
+    +--------+--------------+
+    | 100    | 0.0          |
+    | 100    | 0.0          |
+    | 50     | 0.666667     |
+    | 25     | 1.0          |
+    +--------+--------------+
     ```
 
     To set window function parameters use the window builder approach described in the
     ref:`_window_functions` online documentation.
     """
-    return Expr(f.rank())
+    return Expr(f.percent_rank())
+
+
+def cume_dist() -> Expr:
+    """Create a cumulative distribution window function.
+
+    This window function is similar to :py:func:`rank` except that the returned values
+    are the ratio of the row number to the total numebr of rows. Here is an example of a
+    dataframe with a window ordered by descending ``points`` and the associated
+    cumulative distribution.
+
+    ```
+    +--------+-----------+
+    | points | cume_dist |
+    +--------+-----------+
+    | 100    | 0.5       |
+    | 100    | 0.5       |
+    | 50     | 0.75      |
+    | 25     | 1.0       |
+    +--------+-----------+
+    ```
+
+    To set window function parameters use the window builder approach described in the
+    ref:`_window_functions` online documentation.
+    """
+    return Expr(f.cume_dist())

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -1917,3 +1917,31 @@ def cume_dist() -> Expr:
     ref:`_window_functions` online documentation.
     """
     return Expr(f.cume_dist())
+
+
+def ntile(groups: int) -> Expr:
+    """Create a n-tile window function.
+
+    This window function orders the window frame into a give number of groups based on
+    the ordering criteria. It then returns which group the current row is assigned to.
+    Here is an example of a dataframe with a window ordered by descending ``points``
+    and the associated n-tile function.
+
+    ```
+    +--------+-------+
+    | points | ntile |
+    +--------+-------+
+    | 120    | 1     |
+    | 100    | 1     |
+    | 80     | 2     |
+    | 60     | 2     |
+    | 40     | 3     |
+    | 20     | 3     |
+    +--------+-------+
+    ```
+
+    To set window function parameters use the window builder approach described in the
+    ref:`_window_functions` online documentation.
+    """
+    # Developer note: ntile only accepts literal values.
+    return Expr(f.ntile(Expr.literal(groups).expr))

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -27,6 +27,11 @@ from datafusion._internal import functions as f, common
 from datafusion.expr import CaseBuilder, Expr, WindowFrame
 from datafusion.context import SessionContext
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
 __all__ = [
     "abs",
     "acos",
@@ -247,6 +252,7 @@ __all__ = [
     "var_samp",
     "when",
     "window",
+    "lead",
 ]
 
 
@@ -1022,12 +1028,12 @@ def struct(*args: Expr) -> Expr:
     return Expr(f.struct(*args))
 
 
-def named_struct(name_pairs: list[(str, Expr)]) -> Expr:
+def named_struct(name_pairs: list[tuple[str, Expr]]) -> Expr:
     """Returns a struct with the given names and arguments pairs."""
-    name_pairs = [[Expr.literal(pair[0]), pair[1]] for pair in name_pairs]
+    name_pair_exprs = [[Expr.literal(pair[0]), pair[1]] for pair in name_pairs]
 
     # flatten
-    name_pairs = [x.expr for xs in name_pairs for x in xs]
+    name_pairs = [x.expr for xs in name_pair_exprs for x in xs]
     return Expr(f.named_struct(*name_pairs))
 
 
@@ -1748,3 +1754,7 @@ def bool_and(arg: Expr, distinct: bool = False) -> Expr:
 def bool_or(arg: Expr, distinct: bool = False) -> Expr:
     """Computes the boolean OR of the arguement."""
     return Expr(f.bool_or(arg.expr, distinct=distinct))
+
+
+def lead(arg: Expr, shift_offset: int = 1, default_value: pa.Scalar | None = None):
+    return Expr(f.lead(arg.expr, shift_offset, default_value))

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -251,9 +251,14 @@ __all__ = [
     "var_pop",
     "var_samp",
     "when",
+    # Window Functions
     "window",
     "lead",
     "lag",
+    "row_number",
+    "rank",
+    "dense_rank",
+    "percent_rank",
 ]
 
 
@@ -1820,6 +1825,8 @@ def rank() -> Expr:
     is an example of a dataframe with a window ordered by descending ``points`` and the
     associated rank.
 
+    You should set ``order_by`` to produce meaningful results.
+
     ```
     +--------+------+
     | points | rank |
@@ -1827,6 +1834,55 @@ def rank() -> Expr:
     | 100    | 1    |
     | 100    | 1    |
     | 50     | 3    |
+    | 25     | 4    |
+    +--------+------+
+    ```
+
+    To set window function parameters use the window builder approach described in the
+    ref:`_window_functions` online documentation.
+    """
+    return Expr(f.rank())
+
+
+def dense_rank() -> Expr:
+    """Create a dense_rank window function.
+
+    This window function is similar to :py:func:`rank` except that the returned values
+    will be consecutive. Here is an example of a dataframe with a window ordered by
+    descending ``points`` and the associated dense rank.
+
+    ```
+    +--------+------------+
+    | points | dense_rank |
+    +--------+------------+
+    | 100    | 1          |
+    | 100    | 1          |
+    | 50     | 2          |
+    | 25     | 3          |
+    +--------+------------+
+    ```
+
+    To set window function parameters use the window builder approach described in the
+    ref:`_window_functions` online documentation.
+    """
+    return Expr(f.rank())
+
+
+def percent_rank() -> Expr:
+    """Create a percent_rank window function.
+
+    This window function is similar to :py:func:`rank` except that the returned values
+    will be consecutive. Here is an example of a dataframe with a window ordered by
+    descending ``points`` and the associated dense rank.
+
+    ```
+    +--------+------+
+    | points | rank |
+    +--------+------+
+    | 100    | 1    |
+    | 100    | 1    |
+    | 50     | 2    |
+    | 25     | 3    |
     +--------+------+
     ```
 

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -1770,6 +1770,18 @@ def lead(arg: Expr, shift_offset: int = 1, default_value: Optional[Any] = None) 
     return the 3rd following value in column ``b``. At the end of the partition, where
     no futher values can be returned it will return the default value of 5.
 
+    Here is an example of both the ``lead`` and :py:func:`datafusion.functions.lag`
+    functions on a simple DataFrame::
+
+        +--------+------+-----+
+        | points | lead | lag |
+        +--------+------+-----+
+        | 100    | 100  |     |
+        | 100    | 50   | 100 |
+        | 50     | 25   | 100 |
+        | 25     |      | 50  |
+        +--------+------+-----+
+
     To set window function parameters use the window builder approach described in the
     ref:`_window_functions` online documentation.
 
@@ -1792,6 +1804,18 @@ def lag(arg: Expr, shift_offset: int = 1, default_value: Optional[Any] = None) -
     will return the 3rd previous value in column ``b``. At the beginnig of the
     partition, where no values can be returned it will return the default value of 5.
 
+    Here is an example of both the ``lag`` and :py:func:`datafusion.functions.lead`
+    functions on a simple DataFrame::
+
+        +--------+------+-----+
+        | points | lead | lag |
+        +--------+------+-----+
+        | 100    | 100  |     |
+        | 100    | 50   | 100 |
+        | 50     | 25   | 100 |
+        | 25     |      | 50  |
+        +--------+------+-----+
+
     To set window function parameters use the window builder approach described in the
     ref:`_window_functions` online documentation.
 
@@ -1810,6 +1834,17 @@ def row_number() -> Expr:
     """Create a row number window function.
 
     Returns the row number of the window function.
+
+    Here is an example of the ``row_number`` on a simple DataFrame::
+
+        +--------+------------+
+        | points | row number |
+        +--------+------------+
+        | 100    | 1          |
+        | 100    | 2          |
+        | 50     | 3          |
+        | 25     | 4          |
+        +--------+------------+
 
     To set window function parameters use the window builder approach described in the
     ref:`_window_functions` online documentation.

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -1766,7 +1766,6 @@ def lead(
     default_value: Optional[Any] = None,
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a lead window function.
 
@@ -1796,7 +1795,6 @@ def lead(
         default_value: Value to return if shift_offet row does not exist.
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        null_treatment: Specify how nulls are to be treated.
     """
     if not isinstance(default_value, pa.Scalar) and default_value is not None:
         default_value = pa.scalar(default_value)
@@ -1813,7 +1811,6 @@ def lead(
             default_value,
             partition_by=partition_cols,
             order_by=order_cols,
-            null_treatment=null_treatment,
         )
     )
 
@@ -1824,7 +1821,6 @@ def lag(
     default_value: Optional[Any] = None,
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a lag window function.
 
@@ -1851,7 +1847,6 @@ def lag(
         default_value: Value to return if shift_offet row does not exist.
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        null_treatment: Specify how nulls are to be treated.
     """
     if not isinstance(default_value, pa.Scalar):
         default_value = pa.scalar(default_value)
@@ -1868,7 +1863,6 @@ def lag(
             default_value,
             partition_by=partition_cols,
             order_by=order_cols,
-            null_treatment=null_treatment,
         )
     )
 
@@ -1876,7 +1870,6 @@ def lag(
 def row_number(
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a row number window function.
 
@@ -1896,7 +1889,6 @@ def row_number(
     Args:
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        null_treatment: Specify how nulls are to be treated.
     """
     partition_cols = (
         [col.expr for col in partition_by] if partition_by is not None else None
@@ -1907,7 +1899,6 @@ def row_number(
         f.row_number(
             partition_by=partition_cols,
             order_by=order_cols,
-            null_treatment=null_treatment,
         )
     )
 
@@ -1915,7 +1906,6 @@ def row_number(
 def rank(
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a rank window function.
 
@@ -1940,7 +1930,6 @@ def rank(
     Args:
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        null_treatment: Specify how nulls are to be treated.
     """
     partition_cols = (
         [col.expr for col in partition_by] if partition_by is not None else None
@@ -1951,7 +1940,6 @@ def rank(
         f.rank(
             partition_by=partition_cols,
             order_by=order_cols,
-            null_treatment=null_treatment,
         )
     )
 
@@ -1959,7 +1947,6 @@ def rank(
 def dense_rank(
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a dense_rank window function.
 
@@ -1979,7 +1966,6 @@ def dense_rank(
     Args:
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        null_treatment: Specify how nulls are to be treated.
     """
     partition_cols = (
         [col.expr for col in partition_by] if partition_by is not None else None
@@ -1990,7 +1976,6 @@ def dense_rank(
         f.dense_rank(
             partition_by=partition_cols,
             order_by=order_cols,
-            null_treatment=null_treatment,
         )
     )
 
@@ -1998,7 +1983,6 @@ def dense_rank(
 def percent_rank(
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a percent_rank window function.
 
@@ -2019,7 +2003,6 @@ def percent_rank(
     Args:
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        null_treatment: Specify how nulls are to be treated.
     """
     partition_cols = (
         [col.expr for col in partition_by] if partition_by is not None else None
@@ -2030,7 +2013,6 @@ def percent_rank(
         f.percent_rank(
             partition_by=partition_cols,
             order_by=order_cols,
-            null_treatment=null_treatment,
         )
     )
 
@@ -2038,7 +2020,6 @@ def percent_rank(
 def cume_dist(
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a cumulative distribution window function.
 
@@ -2059,7 +2040,6 @@ def cume_dist(
     Args:
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        null_treatment: Specify how nulls are to be treated.
     """
     partition_cols = (
         [col.expr for col in partition_by] if partition_by is not None else None
@@ -2070,7 +2050,6 @@ def cume_dist(
         f.cume_dist(
             partition_by=partition_cols,
             order_by=order_cols,
-            null_treatment=null_treatment,
         )
     )
 
@@ -2079,7 +2058,6 @@ def ntile(
     groups: int,
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a n-tile window function.
 
@@ -2103,7 +2081,6 @@ def ntile(
         groups: Number of groups for the n-tile to be divided into.
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        null_treatment: Specify how nulls are to be treated.
     """
     partition_cols = (
         [col.expr for col in partition_by] if partition_by is not None else None
@@ -2115,6 +2092,5 @@ def ntile(
             Expr.literal(groups).expr,
             partition_by=partition_cols,
             order_by=order_cols,
-            null_treatment=null_treatment,
         )
     )

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -1763,6 +1763,9 @@ def lead(arg: Expr, shift_offset: int = 1, default_value: Optional[Any] = None) 
     return the 3rd following value in column ``b``. At the end of the partition, where
     no futher values can be returned it will return the default value of 5.
 
+    To set window function parameters use the window builder approach described in the
+    ref:`_window_functions` online documentation.
+
     Args:
         arg: Value to return
         shift_offset: Number of rows following the current row.
@@ -1782,6 +1785,9 @@ def lag(arg: Expr, shift_offset: int = 1, default_value: Optional[Any] = None) -
     will return the 3rd previous value in column ``b``. At the beginnig of the
     partition, where no values can be returned it will return the default value of 5.
 
+    To set window function parameters use the window builder approach described in the
+    ref:`_window_functions` online documentation.
+
     Args:
         arg: Value to return
         shift_offset: Number of rows before the current row.
@@ -1796,8 +1802,35 @@ def lag(arg: Expr, shift_offset: int = 1, default_value: Optional[Any] = None) -
 def row_number() -> Expr:
     """Create a row number window function.
 
-    Returns the row number of the window function. To set window function parameters
-    use the window builder approach described in the ref:`_window_functions` online
-    documentation.
+    Returns the row number of the window function.
+
+    To set window function parameters use the window builder approach described in the
+    ref:`_window_functions` online documentation.
     """
     return Expr(f.row_number())
+
+
+def rank() -> Expr:
+    """Create a rank window function.
+
+    Returns the rank based upon the window order. Consecutive equal values will receive
+    the same rank, but the next different value will not be consecutive but rather the
+    number of rows that preceed it plus one. This is similar to Olympic medals. If two
+    people tie for gold, the next place is bronze. There would be no silver medal. Here
+    is an example of a dataframe with a window ordered by descending ``points`` and the
+    associated rank.
+
+    ```
+    +--------+------+
+    | points | rank |
+    +--------+------+
+    | 100    | 1    |
+    | 100    | 1    |
+    | 50     | 3    |
+    +--------+------+
+    ```
+
+    To set window function parameters use the window builder approach described in the
+    ref:`_window_functions` online documentation.
+    """
+    return Expr(f.rank())

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -399,12 +399,11 @@ def window(
 ) -> Expr:
     """Creates a new Window function expression.
 
-    This interface is deprecateted. Instead of using this interface, users should call
-    the window functions directly. For example, to perform a lag use
+    This interface will soon be deprecated. Instead of using this interface,
+    users should call the window functions directly. For example, to perform a
+    lag use::
 
-    ```
-    df.select(functions.lag(col("a")).partition_by(col("b")).build())
-    ```
+        df.select(functions.lag(col("a")).partition_by(col("b")).build())
     """
     args = [a.expr for a in args]
     partition_by = [e.expr for e in partition_by] if partition_by is not None else None
@@ -1768,7 +1767,6 @@ def lead(
     default_value: Optional[Any] = None,
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    window_frame: Optional[WindowFrame] = None,
     null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a lead window function.
@@ -1799,7 +1797,6 @@ def lead(
         default_value: Value to return if shift_offet row does not exist.
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        window_frame: Override default window frame.
         null_treatment: Specify how nulls are to be treated.
     """
     if not isinstance(default_value, pa.Scalar) and default_value is not None:
@@ -1809,7 +1806,6 @@ def lead(
         [col.expr for col in partition_by] if partition_by is not None else None
     )
     order_cols = [col.expr for col in order_by] if order_by is not None else None
-    window_val = window_frame.window_frame if window_frame is not None else None
 
     return Expr(
         f.lead(
@@ -1818,7 +1814,6 @@ def lead(
             default_value,
             partition_by=partition_cols,
             order_by=order_cols,
-            window_frame=window_val,
             null_treatment=null_treatment,
         )
     )
@@ -1830,7 +1825,6 @@ def lag(
     default_value: Optional[Any] = None,
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    window_frame: Optional[WindowFrame] = None,
     null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a lag window function.
@@ -1858,7 +1852,6 @@ def lag(
         default_value: Value to return if shift_offet row does not exist.
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        window_frame: Override default window frame.
         null_treatment: Specify how nulls are to be treated.
     """
     if not isinstance(default_value, pa.Scalar):
@@ -1868,7 +1861,6 @@ def lag(
         [col.expr for col in partition_by] if partition_by is not None else None
     )
     order_cols = [col.expr for col in order_by] if order_by is not None else None
-    window_val = window_frame.window_frame if window_frame is not None else None
 
     return Expr(
         f.lag(
@@ -1877,7 +1869,6 @@ def lag(
             default_value,
             partition_by=partition_cols,
             order_by=order_cols,
-            window_frame=window_val,
             null_treatment=null_treatment,
         )
     )
@@ -1886,7 +1877,6 @@ def lag(
 def row_number(
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    window_frame: Optional[WindowFrame] = None,
     null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a row number window function.
@@ -1907,20 +1897,17 @@ def row_number(
     Args:
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        window_frame: Override default window frame.
         null_treatment: Specify how nulls are to be treated.
     """
     partition_cols = (
         [col.expr for col in partition_by] if partition_by is not None else None
     )
     order_cols = [col.expr for col in order_by] if order_by is not None else None
-    window_val = window_frame.window_frame if window_frame is not None else None
 
     return Expr(
         f.row_number(
             partition_by=partition_cols,
             order_by=order_cols,
-            window_frame=window_val,
             null_treatment=null_treatment,
         )
     )
@@ -1929,7 +1916,6 @@ def row_number(
 def rank(
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    window_frame: Optional[WindowFrame] = None,
     null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a rank window function.
@@ -1955,20 +1941,17 @@ def rank(
     Args:
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        window_frame: Override default window frame.
         null_treatment: Specify how nulls are to be treated.
     """
     partition_cols = (
         [col.expr for col in partition_by] if partition_by is not None else None
     )
     order_cols = [col.expr for col in order_by] if order_by is not None else None
-    window_val = window_frame.window_frame if window_frame is not None else None
 
     return Expr(
         f.rank(
             partition_by=partition_cols,
             order_by=order_cols,
-            window_frame=window_val,
             null_treatment=null_treatment,
         )
     )
@@ -1977,7 +1960,6 @@ def rank(
 def dense_rank(
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    window_frame: Optional[WindowFrame] = None,
     null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a dense_rank window function.
@@ -1998,20 +1980,17 @@ def dense_rank(
     Args:
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        window_frame: Override default window frame.
         null_treatment: Specify how nulls are to be treated.
     """
     partition_cols = (
         [col.expr for col in partition_by] if partition_by is not None else None
     )
     order_cols = [col.expr for col in order_by] if order_by is not None else None
-    window_val = window_frame.window_frame if window_frame is not None else None
 
     return Expr(
         f.dense_rank(
             partition_by=partition_cols,
             order_by=order_cols,
-            window_frame=window_val,
             null_treatment=null_treatment,
         )
     )
@@ -2020,7 +1999,6 @@ def dense_rank(
 def percent_rank(
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    window_frame: Optional[WindowFrame] = None,
     null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a percent_rank window function.
@@ -2042,20 +2020,17 @@ def percent_rank(
     Args:
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        window_frame: Override default window frame.
         null_treatment: Specify how nulls are to be treated.
     """
     partition_cols = (
         [col.expr for col in partition_by] if partition_by is not None else None
     )
     order_cols = [col.expr for col in order_by] if order_by is not None else None
-    window_val = window_frame.window_frame if window_frame is not None else None
 
     return Expr(
         f.percent_rank(
             partition_by=partition_cols,
             order_by=order_cols,
-            window_frame=window_val,
             null_treatment=null_treatment,
         )
     )
@@ -2064,7 +2039,6 @@ def percent_rank(
 def cume_dist(
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    window_frame: Optional[WindowFrame] = None,
     null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a cumulative distribution window function.
@@ -2086,20 +2060,17 @@ def cume_dist(
     Args:
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        window_frame: Override default window frame.
         null_treatment: Specify how nulls are to be treated.
     """
     partition_cols = (
         [col.expr for col in partition_by] if partition_by is not None else None
     )
     order_cols = [col.expr for col in order_by] if order_by is not None else None
-    window_val = window_frame.window_frame if window_frame is not None else None
 
     return Expr(
         f.cume_dist(
             partition_by=partition_cols,
             order_by=order_cols,
-            window_frame=window_val,
             null_treatment=null_treatment,
         )
     )
@@ -2109,7 +2080,6 @@ def ntile(
     groups: int,
     partition_by: Optional[list[Expr]] = None,
     order_by: Optional[list[Expr]] = None,
-    window_frame: Optional[WindowFrame] = None,
     null_treatment: Optional[common.NullTreatment] = None,
 ) -> Expr:
     """Create a n-tile window function.
@@ -2134,21 +2104,18 @@ def ntile(
         groups: Number of groups for the n-tile to be divided into.
         partition_by: Expressions to partition the window frame on.
         order_by: Set ordering within the window frame.
-        window_frame: Override default window frame.
         null_treatment: Specify how nulls are to be treated.
     """
     partition_cols = (
         [col.expr for col in partition_by] if partition_by is not None else None
     )
     order_cols = [col.expr for col in order_by] if order_by is not None else None
-    window_val = window_frame.window_frame if window_frame is not None else None
 
     return Expr(
         f.ntile(
             Expr.literal(groups).expr,
             partition_by=partition_cols,
             order_by=order_cols,
-            window_frame=window_val,
             null_treatment=null_treatment,
         )
     )

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -1762,7 +1762,15 @@ def bool_or(arg: Expr, distinct: bool = False) -> Expr:
     return Expr(f.bool_or(arg.expr, distinct=distinct))
 
 
-def lead(arg: Expr, shift_offset: int = 1, default_value: Optional[Any] = None) -> Expr:
+def lead(
+    arg: Expr,
+    shift_offset: int = 1,
+    default_value: Optional[Any] = None,
+    partition_by: Optional[list[Expr]] = None,
+    order_by: Optional[list[Expr]] = None,
+    window_frame: Optional[WindowFrame] = None,
+    null_treatment: Optional[common.NullTreatment] = None,
+) -> Expr:
     """Create a lead window function.
 
     Lead operation will return the argument that is in the next shift_offset-th row in
@@ -1789,14 +1797,42 @@ def lead(arg: Expr, shift_offset: int = 1, default_value: Optional[Any] = None) 
         arg: Value to return
         shift_offset: Number of rows following the current row.
         default_value: Value to return if shift_offet row does not exist.
+        partition_by: Expressions to partition the window frame on.
+        order_by: Set ordering within the window frame.
+        window_frame: Override default window frame.
+        null_treatment: Specify how nulls are to be treated.
     """
-    if not isinstance(default_value, pa.Scalar):
+    if not isinstance(default_value, pa.Scalar) and default_value is not None:
         default_value = pa.scalar(default_value)
 
-    return Expr(f.lead(arg.expr, shift_offset, default_value))
+    partition_cols = (
+        [col.expr for col in partition_by] if partition_by is not None else None
+    )
+    order_cols = [col.expr for col in order_by] if order_by is not None else None
+    window_val = window_frame.window_frame if window_frame is not None else None
+
+    return Expr(
+        f.lead(
+            arg.expr,
+            shift_offset,
+            default_value,
+            partition_by=partition_cols,
+            order_by=order_cols,
+            window_frame=window_val,
+            null_treatment=null_treatment,
+        )
+    )
 
 
-def lag(arg: Expr, shift_offset: int = 1, default_value: Optional[Any] = None) -> Expr:
+def lag(
+    arg: Expr,
+    shift_offset: int = 1,
+    default_value: Optional[Any] = None,
+    partition_by: Optional[list[Expr]] = None,
+    order_by: Optional[list[Expr]] = None,
+    window_frame: Optional[WindowFrame] = None,
+    null_treatment: Optional[common.NullTreatment] = None,
+) -> Expr:
     """Create a lag window function.
 
     Lag operation will return the argument that is in the previous shift_offset-th row
@@ -1816,21 +1852,43 @@ def lag(arg: Expr, shift_offset: int = 1, default_value: Optional[Any] = None) -
         | 25     |      | 50  |
         +--------+------+-----+
 
-    To set window function parameters use the window builder approach described in the
-    ref:`_window_functions` online documentation.
-
     Args:
         arg: Value to return
         shift_offset: Number of rows before the current row.
         default_value: Value to return if shift_offet row does not exist.
+        partition_by: Expressions to partition the window frame on.
+        order_by: Set ordering within the window frame.
+        window_frame: Override default window frame.
+        null_treatment: Specify how nulls are to be treated.
     """
     if not isinstance(default_value, pa.Scalar):
         default_value = pa.scalar(default_value)
 
-    return Expr(f.lag(arg.expr, shift_offset, default_value))
+    partition_cols = (
+        [col.expr for col in partition_by] if partition_by is not None else None
+    )
+    order_cols = [col.expr for col in order_by] if order_by is not None else None
+    window_val = window_frame.window_frame if window_frame is not None else None
+
+    return Expr(
+        f.lag(
+            arg.expr,
+            shift_offset,
+            default_value,
+            partition_by=partition_cols,
+            order_by=order_cols,
+            window_frame=window_val,
+            null_treatment=null_treatment,
+        )
+    )
 
 
-def row_number() -> Expr:
+def row_number(
+    partition_by: Optional[list[Expr]] = None,
+    order_by: Optional[list[Expr]] = None,
+    window_frame: Optional[WindowFrame] = None,
+    null_treatment: Optional[common.NullTreatment] = None,
+) -> Expr:
     """Create a row number window function.
 
     Returns the row number of the window function.
@@ -1846,13 +1904,34 @@ def row_number() -> Expr:
         | 25     | 4          |
         +--------+------------+
 
-    To set window function parameters use the window builder approach described in the
-    ref:`_window_functions` online documentation.
+    Args:
+        partition_by: Expressions to partition the window frame on.
+        order_by: Set ordering within the window frame.
+        window_frame: Override default window frame.
+        null_treatment: Specify how nulls are to be treated.
     """
-    return Expr(f.row_number())
+    partition_cols = (
+        [col.expr for col in partition_by] if partition_by is not None else None
+    )
+    order_cols = [col.expr for col in order_by] if order_by is not None else None
+    window_val = window_frame.window_frame if window_frame is not None else None
+
+    return Expr(
+        f.row_number(
+            partition_by=partition_cols,
+            order_by=order_cols,
+            window_frame=window_val,
+            null_treatment=null_treatment,
+        )
+    )
 
 
-def rank() -> Expr:
+def rank(
+    partition_by: Optional[list[Expr]] = None,
+    order_by: Optional[list[Expr]] = None,
+    window_frame: Optional[WindowFrame] = None,
+    null_treatment: Optional[common.NullTreatment] = None,
+) -> Expr:
     """Create a rank window function.
 
     Returns the rank based upon the window order. Consecutive equal values will receive
@@ -1873,13 +1952,34 @@ def rank() -> Expr:
         | 25     | 4    |
         +--------+------+
 
-    To set window function parameters use the window builder approach described in the
-    ref:`_window_functions` online documentation.
+    Args:
+        partition_by: Expressions to partition the window frame on.
+        order_by: Set ordering within the window frame.
+        window_frame: Override default window frame.
+        null_treatment: Specify how nulls are to be treated.
     """
-    return Expr(f.rank())
+    partition_cols = (
+        [col.expr for col in partition_by] if partition_by is not None else None
+    )
+    order_cols = [col.expr for col in order_by] if order_by is not None else None
+    window_val = window_frame.window_frame if window_frame is not None else None
+
+    return Expr(
+        f.rank(
+            partition_by=partition_cols,
+            order_by=order_cols,
+            window_frame=window_val,
+            null_treatment=null_treatment,
+        )
+    )
 
 
-def dense_rank() -> Expr:
+def dense_rank(
+    partition_by: Optional[list[Expr]] = None,
+    order_by: Optional[list[Expr]] = None,
+    window_frame: Optional[WindowFrame] = None,
+    null_treatment: Optional[common.NullTreatment] = None,
+) -> Expr:
     """Create a dense_rank window function.
 
     This window function is similar to :py:func:`rank` except that the returned values
@@ -1895,13 +1995,34 @@ def dense_rank() -> Expr:
         | 25     | 3          |
         +--------+------------+
 
-    To set window function parameters use the window builder approach described in the
-    ref:`_window_functions` online documentation.
+    Args:
+        partition_by: Expressions to partition the window frame on.
+        order_by: Set ordering within the window frame.
+        window_frame: Override default window frame.
+        null_treatment: Specify how nulls are to be treated.
     """
-    return Expr(f.dense_rank())
+    partition_cols = (
+        [col.expr for col in partition_by] if partition_by is not None else None
+    )
+    order_cols = [col.expr for col in order_by] if order_by is not None else None
+    window_val = window_frame.window_frame if window_frame is not None else None
+
+    return Expr(
+        f.dense_rank(
+            partition_by=partition_cols,
+            order_by=order_cols,
+            window_frame=window_val,
+            null_treatment=null_treatment,
+        )
+    )
 
 
-def percent_rank() -> Expr:
+def percent_rank(
+    partition_by: Optional[list[Expr]] = None,
+    order_by: Optional[list[Expr]] = None,
+    window_frame: Optional[WindowFrame] = None,
+    null_treatment: Optional[common.NullTreatment] = None,
+) -> Expr:
     """Create a percent_rank window function.
 
     This window function is similar to :py:func:`rank` except that the returned values
@@ -1918,13 +2039,34 @@ def percent_rank() -> Expr:
         | 25     | 1.0          |
         +--------+--------------+
 
-    To set window function parameters use the window builder approach described in the
-    ref:`_window_functions` online documentation.
+    Args:
+        partition_by: Expressions to partition the window frame on.
+        order_by: Set ordering within the window frame.
+        window_frame: Override default window frame.
+        null_treatment: Specify how nulls are to be treated.
     """
-    return Expr(f.percent_rank())
+    partition_cols = (
+        [col.expr for col in partition_by] if partition_by is not None else None
+    )
+    order_cols = [col.expr for col in order_by] if order_by is not None else None
+    window_val = window_frame.window_frame if window_frame is not None else None
+
+    return Expr(
+        f.percent_rank(
+            partition_by=partition_cols,
+            order_by=order_cols,
+            window_frame=window_val,
+            null_treatment=null_treatment,
+        )
+    )
 
 
-def cume_dist() -> Expr:
+def cume_dist(
+    partition_by: Optional[list[Expr]] = None,
+    order_by: Optional[list[Expr]] = None,
+    window_frame: Optional[WindowFrame] = None,
+    null_treatment: Optional[common.NullTreatment] = None,
+) -> Expr:
     """Create a cumulative distribution window function.
 
     This window function is similar to :py:func:`rank` except that the returned values
@@ -1941,13 +2083,35 @@ def cume_dist() -> Expr:
         | 25     | 1.0       |
         +--------+-----------+
 
-    To set window function parameters use the window builder approach described in the
-    ref:`_window_functions` online documentation.
+    Args:
+        partition_by: Expressions to partition the window frame on.
+        order_by: Set ordering within the window frame.
+        window_frame: Override default window frame.
+        null_treatment: Specify how nulls are to be treated.
     """
-    return Expr(f.cume_dist())
+    partition_cols = (
+        [col.expr for col in partition_by] if partition_by is not None else None
+    )
+    order_cols = [col.expr for col in order_by] if order_by is not None else None
+    window_val = window_frame.window_frame if window_frame is not None else None
+
+    return Expr(
+        f.cume_dist(
+            partition_by=partition_cols,
+            order_by=order_cols,
+            window_frame=window_val,
+            null_treatment=null_treatment,
+        )
+    )
 
 
-def ntile(groups: int) -> Expr:
+def ntile(
+    groups: int,
+    partition_by: Optional[list[Expr]] = None,
+    order_by: Optional[list[Expr]] = None,
+    window_frame: Optional[WindowFrame] = None,
+    null_treatment: Optional[common.NullTreatment] = None,
+) -> Expr:
     """Create a n-tile window function.
 
     This window function orders the window frame into a give number of groups based on
@@ -1966,7 +2130,25 @@ def ntile(groups: int) -> Expr:
         | 20     | 3     |
         +--------+-------+
 
-    To set window function parameters use the window builder approach described in the
-    ref:`_window_functions` online documentation.
+    Args:
+        groups: Number of groups for the n-tile to be divided into.
+        partition_by: Expressions to partition the window frame on.
+        order_by: Set ordering within the window frame.
+        window_frame: Override default window frame.
+        null_treatment: Specify how nulls are to be treated.
     """
-    return Expr(f.ntile(Expr.literal(groups).expr))
+    partition_cols = (
+        [col.expr for col in partition_by] if partition_by is not None else None
+    )
+    order_cols = [col.expr for col in order_by] if order_by is not None else None
+    window_val = window_frame.window_frame if window_frame is not None else None
+
+    return Expr(
+        f.ntile(
+            Expr.literal(groups).expr,
+            partition_by=partition_cols,
+            order_by=order_cols,
+            window_frame=window_val,
+            null_treatment=null_treatment,
+        )
+    )

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -1791,3 +1791,13 @@ def lag(arg: Expr, shift_offset: int = 1, default_value: Optional[Any] = None) -
         default_value = pa.scalar(default_value)
 
     return Expr(f.lag(arg.expr, shift_offset, default_value))
+
+
+def row_number() -> Expr:
+    """Create a row number window function.
+
+    Returns the row number of the window function. To set window function parameters
+    use the window builder approach described in the ref:`_window_functions` online
+    documentation.
+    """
+    return Expr(f.row_number())

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -260,6 +260,7 @@ __all__ = [
     "dense_rank",
     "percent_rank",
     "cume_dist",
+    "ntile",
 ]
 
 
@@ -1826,18 +1827,16 @@ def rank() -> Expr:
     is an example of a dataframe with a window ordered by descending ``points`` and the
     associated rank.
 
-    You should set ``order_by`` to produce meaningful results.
+    You should set ``order_by`` to produce meaningful results::
 
-    ```
-    +--------+------+
-    | points | rank |
-    +--------+------+
-    | 100    | 1    |
-    | 100    | 1    |
-    | 50     | 3    |
-    | 25     | 4    |
-    +--------+------+
-    ```
+        +--------+------+
+        | points | rank |
+        +--------+------+
+        | 100    | 1    |
+        | 100    | 1    |
+        | 50     | 3    |
+        | 25     | 4    |
+        +--------+------+
 
     To set window function parameters use the window builder approach described in the
     ref:`_window_functions` online documentation.
@@ -1850,18 +1849,16 @@ def dense_rank() -> Expr:
 
     This window function is similar to :py:func:`rank` except that the returned values
     will be consecutive. Here is an example of a dataframe with a window ordered by
-    descending ``points`` and the associated dense rank.
+    descending ``points`` and the associated dense rank::
 
-    ```
-    +--------+------------+
-    | points | dense_rank |
-    +--------+------------+
-    | 100    | 1          |
-    | 100    | 1          |
-    | 50     | 2          |
-    | 25     | 3          |
-    +--------+------------+
-    ```
+        +--------+------------+
+        | points | dense_rank |
+        +--------+------------+
+        | 100    | 1          |
+        | 100    | 1          |
+        | 50     | 2          |
+        | 25     | 3          |
+        +--------+------------+
 
     To set window function parameters use the window builder approach described in the
     ref:`_window_functions` online documentation.
@@ -1875,18 +1872,16 @@ def percent_rank() -> Expr:
     This window function is similar to :py:func:`rank` except that the returned values
     are the percentage from 0.0 to 1.0 from first to last. Here is an example of a
     dataframe with a window ordered by descending ``points`` and the associated percent
-    rank.
+    rank::
 
-    ```
-    +--------+--------------+
-    | points | percent_rank |
-    +--------+--------------+
-    | 100    | 0.0          |
-    | 100    | 0.0          |
-    | 50     | 0.666667     |
-    | 25     | 1.0          |
-    +--------+--------------+
-    ```
+        +--------+--------------+
+        | points | percent_rank |
+        +--------+--------------+
+        | 100    | 0.0          |
+        | 100    | 0.0          |
+        | 50     | 0.666667     |
+        | 25     | 1.0          |
+        +--------+--------------+
 
     To set window function parameters use the window builder approach described in the
     ref:`_window_functions` online documentation.
@@ -1900,18 +1895,16 @@ def cume_dist() -> Expr:
     This window function is similar to :py:func:`rank` except that the returned values
     are the ratio of the row number to the total numebr of rows. Here is an example of a
     dataframe with a window ordered by descending ``points`` and the associated
-    cumulative distribution.
+    cumulative distribution::
 
-    ```
-    +--------+-----------+
-    | points | cume_dist |
-    +--------+-----------+
-    | 100    | 0.5       |
-    | 100    | 0.5       |
-    | 50     | 0.75      |
-    | 25     | 1.0       |
-    +--------+-----------+
-    ```
+        +--------+-----------+
+        | points | cume_dist |
+        +--------+-----------+
+        | 100    | 0.5       |
+        | 100    | 0.5       |
+        | 50     | 0.75      |
+        | 25     | 1.0       |
+        +--------+-----------+
 
     To set window function parameters use the window builder approach described in the
     ref:`_window_functions` online documentation.
@@ -1925,23 +1918,20 @@ def ntile(groups: int) -> Expr:
     This window function orders the window frame into a give number of groups based on
     the ordering criteria. It then returns which group the current row is assigned to.
     Here is an example of a dataframe with a window ordered by descending ``points``
-    and the associated n-tile function.
+    and the associated n-tile function::
 
-    ```
-    +--------+-------+
-    | points | ntile |
-    +--------+-------+
-    | 120    | 1     |
-    | 100    | 1     |
-    | 80     | 2     |
-    | 60     | 2     |
-    | 40     | 3     |
-    | 20     | 3     |
-    +--------+-------+
-    ```
+        +--------+-------+
+        | points | ntile |
+        +--------+-------+
+        | 120    | 1     |
+        | 100    | 1     |
+        | 80     | 2     |
+        | 60     | 2     |
+        | 40     | 3     |
+        | 20     | 3     |
+        +--------+-------+
 
     To set window function parameters use the window builder approach described in the
     ref:`_window_functions` online documentation.
     """
-    # Developer note: ntile only accepts literal values.
     return Expr(f.ntile(Expr.literal(groups).expr))

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -30,6 +30,7 @@ from datafusion import (
     literal,
     udf,
 )
+from datafusion.common import NullTreatment
 
 
 @pytest.fixture
@@ -82,6 +83,23 @@ def aggregate_df():
     ctx = SessionContext()
     ctx.register_csv("test", "testing/data/csv/aggregate_test_100.csv")
     return ctx.sql("select c1, sum(c2) from test group by c1")
+
+
+@pytest.fixture
+def partitioned_df():
+    ctx = SessionContext()
+
+    # create a RecordBatch and a new DataFrame from it
+    batch = pa.RecordBatch.from_arrays(
+        [
+            pa.array([0, 1, 2, 3, 4, 5, 6]),
+            pa.array([7, None, 7, 8, 9, None, 9]),
+            pa.array(["A", "A", "A", "A", "B", "B", "B"]),
+        ],
+        names=["a", "b", "c"],
+    )
+
+    return ctx.create_dataframe([[batch]])
 
 
 def test_select(df):
@@ -279,79 +297,154 @@ def test_distinct():
 
 
 data_test_window_functions = [
-    ("row", f.row_number().order_by(column("c").sort()).build(), [2, 1, 3]),
-    ("rank", f.rank().order_by(column("c").sort()).build(), [2, 1, 2]),
+    (
+        "row",
+        f.row_number(order_by=[column("b"), column("a").sort(ascending=False)]),
+        [4, 2, 3, 5, 7, 1, 6],
+    ),
+    (
+        "row_w_params",
+        f.row_number(
+            order_by=[column("b"), column("a")],
+            partition_by=[column("c")],
+            window_frame=WindowFrame("rows", 1, 0),
+            null_treatment=NullTreatment.RESPECT_NULLS,
+        ),
+        [2, 1, 3, 4, 2, 1, 3],
+    ),
+    ("rank", f.rank(order_by=[column("b")]), [3, 1, 3, 5, 6, 1, 6]),
+    (
+        "rank_w_params",
+        f.rank(order_by=[column("b"), column("a")], partition_by=[column("c")]),
+        [2, 1, 3, 4, 2, 1, 3],
+    ),
     (
         "dense_rank",
-        f.dense_rank().order_by((column("c").sort())).build(),
-        [2, 1, 2],
+        f.dense_rank(order_by=[column("b")]),
+        [2, 1, 2, 3, 4, 1, 4],
+    ),
+    (
+        "dense_rank_w_params",
+        f.dense_rank(order_by=[column("b"), column("a")], partition_by=[column("c")]),
+        [2, 1, 3, 4, 2, 1, 3],
     ),
     (
         "percent_rank",
-        f.percent_rank().order_by(column("c").sort()).build(),
-        [0.5, 0, 0.5],
+        f.round(f.percent_rank(order_by=[column("b")]), literal(3)),
+        [0.333, 0.0, 0.333, 0.667, 0.833, 0.0, 0.833],
+    ),
+    (
+        "percent_rank_w_params",
+        f.round(
+            f.percent_rank(
+                order_by=[column("b"), column("a")], partition_by=[column("c")]
+            ),
+            literal(3),
+        ),
+        [0.333, 0.0, 0.667, 1.0, 0.5, 0.0, 1.0],
     ),
     (
         "cume_dist",
-        f.cume_dist().order_by(column("b").sort()).build(),
-        [0.3333333333333333, 0.6666666666666666, 1.0],
+        f.round(f.cume_dist(order_by=[column("b")]), literal(3)),
+        [0.571, 0.286, 0.571, 0.714, 1.0, 0.286, 1.0],
+    ),
+    (
+        "cume_dist_w_params",
+        f.round(
+            f.cume_dist(
+                order_by=[column("b"), column("a")], partition_by=[column("c")]
+            ),
+            literal(3),
+        ),
+        [0.5, 0.25, 0.75, 1.0, 0.667, 0.333, 1.0],
     ),
     (
         "ntile",
-        f.ntile(2).order_by(column("c").sort()).build(),
-        [1, 1, 2],
+        f.ntile(2, order_by=[column("b")]),
+        [1, 1, 1, 2, 2, 1, 2],
     ),
-    ("lead", f.lead(column("b")).order_by(column("b").sort()).build(), [5, 6, None]),
     (
-        "lead_by_2",
-        f.lead(column("b"), shift_offset=2, default_value=-1)
-        .order_by(column("b").sort())
-        .build(),
-        [6, -1, -1],
+        "ntile_w_params",
+        f.ntile(2, order_by=[column("b"), column("a")], partition_by=[column("c")]),
+        [1, 1, 2, 2, 1, 1, 2],
     ),
-    ("lag", f.lag(column("b")).order_by(column("b").sort()).build(), [None, 4, 5]),
+    ("lead", f.lead(column("b"), order_by=[column("b")]), [7, None, 8, 9, 9, 7, None]),
     (
-        "lag_by_2",
-        f.lag(column("b"), shift_offset=2, default_value=-1)
-        .order_by(column("b").sort())
-        .build(),
-        [-1, -1, 4],
+        "lead_w_params",
+        f.lead(
+            column("b"),
+            shift_offset=2,
+            default_value=-1,
+            order_by=[column("b"), column("a")],
+            partition_by=[column("c")],
+            window_frame=WindowFrame("rows", 3, 0),
+        ),
+        [8, 7, -1, -1, -1, 9, -1],
+    ),
+    ("lag", f.lag(column("b"), order_by=[column("b")]), [None, None, 7, 7, 8, None, 9]),
+    (
+        "lag_w_params",
+        f.lag(
+            column("b"),
+            shift_offset=2,
+            default_value=-1,
+            order_by=[column("b"), column("a")],
+            partition_by=[column("c")],
+            window_frame=WindowFrame("rows", 3, 0),
+        ),
+        [-1, -1, None, 7, -1, -1, None],
     ),
     # TODO update all aggregate functions as windows once upstream merges https://github.com/apache/datafusion-python/issues/833
     pytest.param(
         "first_value",
-        f.window("first_value", [column("a")], order_by=[f.order_by(column("b"))]),
-        [1, 1, 1],
+        f.window(
+            "first_value",
+            [column("a")],
+            order_by=[f.order_by(column("b"))],
+            partition_by=[column("c")],
+        ),
+        [1, 1, 1, 1, 5, 5, 5],
     ),
     pytest.param(
         "last_value",
-        f.window("last_value", [column("b")], order_by=[f.order_by(column("b"))]),
-        [4, 5, 6],
+        f.window("last_value", [column("a")])
+        .window_frame(WindowFrame("rows", 0, None))
+        .order_by(column("b").sort())
+        .partition_by(column("c"))
+        .build(),
+        [3, 3, 3, 3, 6, 6, 6],
     ),
     pytest.param(
-        "2nd_value",
+        "3rd_value",
         f.window(
             "nth_value",
-            [column("b"), literal(2)],
-            order_by=[f.order_by(column("b"))],
+            [column("b"), literal(3)],
+            order_by=[f.order_by(column("a"))],
         ),
-        [None, 5, 5],
+        [None, None, 7, 7, 7, 7, 7],
     ),
     pytest.param(
         "avg",
-        f.window("avg", [column("b")]),
-        [4.0, 4.5, 5.0],
+        f.round(f.window("avg", [column("b")]), literal(3)),
+        [7.0, 7.0, 7.0, 7.333, 7.75, 7.75, 8.0],
     ),
 ]
 
 
 @pytest.mark.parametrize("name,expr,result", data_test_window_functions)
-def test_window_functions(df, name, expr, result):
-    df = df.select(column("a"), column("b"), column("c"), f.alias(expr, name))
-
+def test_window_functions(partitioned_df, name, expr, result):
+    df = partitioned_df.select(
+        column("a"), column("b"), column("c"), f.alias(expr, name)
+    )
+    df.sort(column("a").sort()).show()
     table = pa.Table.from_batches(df.collect())
 
-    expected = {"a": [1, 2, 3], "b": [4, 5, 6], "c": [8, 5, 8], name: result}
+    expected = {
+        "a": [0, 1, 2, 3, 4, 5, 6],
+        "b": [7, None, 7, 8, 9, None, 9],
+        "c": ["A", "A", "A", "A", "B", "B", "B"],
+        name: result,
+    }
 
     assert table.sort_by("a").to_pydict() == expected
 

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -306,6 +306,7 @@ data_test_window_functions = [
         f.window("lead", [column("b")], order_by=[f.order_by(column("b"))]),
         [5, 6, None],
     ),
+    ("lead", f.lead(column("b")).order_by(column("b").sort()).build(), [5, 6, None]),
     (
         "previous",
         f.window("lag", [column("b")], order_by=[f.order_by(column("b"))]),

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -280,7 +280,7 @@ def test_distinct():
 
 data_test_window_functions = [
     ("row", f.row_number().order_by(column("c").sort()).build(), [2, 1, 3]),
-    ("rank", f.window("rank", [], order_by=[f.order_by(column("c"))]), [2, 1, 2]),
+    ("rank", f.rank().order_by(column("c").sort()).build(), [2, 1, 2]),
     (
         "dense_rank",
         f.window("dense_rank", [], order_by=[f.order_by(column("c"))]),

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -301,12 +301,14 @@ data_test_window_functions = [
         f.window("ntile", [literal(2)], order_by=[f.order_by(column("c"))]),
         [1, 1, 2],
     ),
-    (
-        "next",
-        f.window("lead", [column("b")], order_by=[f.order_by(column("b"))]),
-        [5, 6, None],
-    ),
     ("lead", f.lead(column("b")).order_by(column("b").sort()).build(), [5, 6, None]),
+    (
+        "lead_by_2",
+        f.lead(column("b"), shift_offset=2, default_value=-1)
+        .order_by(column("b").sort())
+        .build(),
+        [6, -1, -1],
+    ),
     (
         "previous",
         f.window("lag", [column("b")], order_by=[f.order_by(column("b"))]),

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -298,7 +298,7 @@ data_test_window_functions = [
     ),
     (
         "ntile",
-        f.window("ntile", [literal(2)], order_by=[f.order_by(column("c"))]),
+        f.ntile(2).order_by(column("c").sort()).build(),
         [1, 1, 2],
     ),
     ("lead", f.lead(column("b")).order_by(column("b").sort()).build(), [5, 6, None]),

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -283,7 +283,7 @@ data_test_window_functions = [
     ("rank", f.rank().order_by(column("c").sort()).build(), [2, 1, 2]),
     (
         "dense_rank",
-        f.window("dense_rank", [], order_by=[f.order_by(column("c"))]),
+        f.dense_rank().order_by((column("c").sort())).build(),
         [2, 1, 2],
     ),
     (

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -317,7 +317,7 @@ data_test_window_functions = [
         .build(),
         [-1, -1, 4],
     ),
-    # TODO update once upstream merges https://github.com/apache/datafusion-python/issues/833
+    # TODO update all aggregate functions as windows once upstream merges https://github.com/apache/datafusion-python/issues/833
     pytest.param(
         "first_value",
         f.window("first_value", [column("a")], order_by=[f.order_by(column("b"))]),
@@ -336,6 +336,11 @@ data_test_window_functions = [
             order_by=[f.order_by(column("b"))],
         ),
         [None, 5, 5],
+    ),
+    pytest.param(
+        "avg",
+        f.window("avg", [column("b")]),
+        [4.0, 4.5, 5.0],
     ),
 ]
 

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -317,6 +317,7 @@ data_test_window_functions = [
         .build(),
         [-1, -1, 4],
     ),
+    # TODO update once upstream merges https://github.com/apache/datafusion-python/issues/833
     pytest.param(
         "first_value",
         f.window("first_value", [column("a")], order_by=[f.order_by(column("b"))]),

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -279,7 +279,7 @@ def test_distinct():
 
 
 data_test_window_functions = [
-    ("row", f.window("row_number", [], order_by=[f.order_by(column("c"))]), [2, 1, 3]),
+    ("row", f.row_number().order_by(column("c").sort()).build(), [2, 1, 3]),
     ("rank", f.window("rank", [], order_by=[f.order_by(column("c"))]), [2, 1, 2]),
     (
         "dense_rank",

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -267,7 +267,7 @@ def test_join():
 
     df = df.join(df1, join_keys=(["a"], ["a"]), how="inner")
     df.show()
-    df = df.sort(column("l.a").sort(ascending=True))
+    df = df.sort(column("l.a"))
     table = pa.Table.from_batches(df.collect())
 
     expected = {"a": [1, 2], "c": [8, 10], "b": [4, 5]}
@@ -281,17 +281,13 @@ def test_distinct():
         [pa.array([1, 2, 3, 1, 2, 3]), pa.array([4, 5, 6, 4, 5, 6])],
         names=["a", "b"],
     )
-    df_a = (
-        ctx.create_dataframe([[batch]])
-        .distinct()
-        .sort(column("a").sort(ascending=True))
-    )
+    df_a = ctx.create_dataframe([[batch]]).distinct().sort(column("a"))
 
     batch = pa.RecordBatch.from_arrays(
         [pa.array([1, 2, 3]), pa.array([4, 5, 6])],
         names=["a", "b"],
     )
-    df_b = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+    df_b = ctx.create_dataframe([[batch]]).sort(column("a"))
 
     assert df_a.collect() == df_b.collect()
 
@@ -409,7 +405,7 @@ data_test_window_functions = [
         "last_value",
         f.window("last_value", [column("a")])
         .window_frame(WindowFrame("rows", 0, None))
-        .order_by(column("b").sort())
+        .order_by(column("b"))
         .partition_by(column("c"))
         .build(),
         [3, 3, 3, 3, 6, 6, 6],
@@ -436,7 +432,7 @@ def test_window_functions(partitioned_df, name, expr, result):
     df = partitioned_df.select(
         column("a"), column("b"), column("c"), f.alias(expr, name)
     )
-    df.sort(column("a").sort()).show()
+    df.sort(column("a")).show()
     table = pa.Table.from_batches(df.collect())
 
     expected = {
@@ -617,9 +613,9 @@ def test_intersect():
         [pa.array([3]), pa.array([6])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+    df_c = ctx.create_dataframe([[batch]]).sort(column("a"))
 
-    df_a_i_b = df_a.intersect(df_b).sort(column("a").sort(ascending=True))
+    df_a_i_b = df_a.intersect(df_b).sort(column("a"))
 
     assert df_c.collect() == df_a_i_b.collect()
 
@@ -643,9 +639,9 @@ def test_except_all():
         [pa.array([1, 2]), pa.array([4, 5])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+    df_c = ctx.create_dataframe([[batch]]).sort(column("a"))
 
-    df_a_e_b = df_a.except_all(df_b).sort(column("a").sort(ascending=True))
+    df_a_e_b = df_a.except_all(df_b).sort(column("a"))
 
     assert df_c.collect() == df_a_e_b.collect()
 
@@ -678,9 +674,9 @@ def test_union(ctx):
         [pa.array([1, 2, 3, 3, 4, 5]), pa.array([4, 5, 6, 6, 7, 8])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+    df_c = ctx.create_dataframe([[batch]]).sort(column("a"))
 
-    df_a_u_b = df_a.union(df_b).sort(column("a").sort(ascending=True))
+    df_a_u_b = df_a.union(df_b).sort(column("a"))
 
     assert df_c.collect() == df_a_u_b.collect()
 
@@ -702,9 +698,9 @@ def test_union_distinct(ctx):
         [pa.array([1, 2, 3, 4, 5]), pa.array([4, 5, 6, 7, 8])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+    df_c = ctx.create_dataframe([[batch]]).sort(column("a"))
 
-    df_a_u_b = df_a.union(df_b, True).sort(column("a").sort(ascending=True))
+    df_a_u_b = df_a.union(df_b, True).sort(column("a"))
 
     assert df_c.collect() == df_a_u_b.collect()
     assert df_c.collect() == df_a_u_b.collect()

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -303,7 +303,6 @@ data_test_window_functions = [
         f.row_number(
             order_by=[column("b"), column("a")],
             partition_by=[column("c")],
-            window_frame=WindowFrame("rows", 1, 0),
             null_treatment=NullTreatment.RESPECT_NULLS,
         ),
         [2, 1, 3, 4, 2, 1, 3],
@@ -373,7 +372,6 @@ data_test_window_functions = [
             default_value=-1,
             order_by=[column("b"), column("a")],
             partition_by=[column("c")],
-            window_frame=WindowFrame("rows", 3, 0),
         ),
         [8, 7, -1, -1, -1, 9, -1],
     ),
@@ -386,7 +384,6 @@ data_test_window_functions = [
             default_value=-1,
             order_by=[column("b"), column("a")],
             partition_by=[column("c")],
-            window_frame=WindowFrame("rows", 3, 0),
         ),
         [-1, -1, None, 7, -1, -1, None],
     ),
@@ -421,7 +418,7 @@ data_test_window_functions = [
     ),
     pytest.param(
         "avg",
-        f.round(f.window("avg", [column("b")]), literal(3)),
+        f.round(f.window("avg", [column("b")], order_by=[column("a")]), literal(3)),
         [7.0, 7.0, 7.0, 7.333, 7.75, 7.75, 8.0],
     ),
 ]

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -309,10 +309,13 @@ data_test_window_functions = [
         .build(),
         [6, -1, -1],
     ),
+    ("lag", f.lag(column("b")).order_by(column("b").sort()).build(), [None, 4, 5]),
     (
-        "previous",
-        f.window("lag", [column("b")], order_by=[f.order_by(column("b"))]),
-        [None, 4, 5],
+        "lag_by_2",
+        f.lag(column("b"), shift_offset=2, default_value=-1)
+        .order_by(column("b").sort())
+        .build(),
+        [-1, -1, 4],
     ),
     pytest.param(
         "first_value",

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -288,12 +288,12 @@ data_test_window_functions = [
     ),
     (
         "percent_rank",
-        f.window("percent_rank", [], order_by=[f.order_by(column("c"))]),
+        f.percent_rank().order_by(column("c").sort()).build(),
         [0.5, 0, 0.5],
     ),
     (
         "cume_dist",
-        f.window("cume_dist", [], order_by=[f.order_by(column("b"))]),
+        f.cume_dist().order_by(column("b").sort()).build(),
         [0.3333333333333333, 0.6666666666666666, 1.0],
     ),
     (

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -30,7 +30,6 @@ from datafusion import (
     literal,
     udf,
 )
-from datafusion.common import NullTreatment
 
 
 @pytest.fixture
@@ -303,7 +302,6 @@ data_test_window_functions = [
         f.row_number(
             order_by=[column("b"), column("a")],
             partition_by=[column("c")],
-            null_treatment=NullTreatment.RESPECT_NULLS,
         ),
         [2, 1, 3, 4, 2, 1, 3],
     ),

--- a/python/datafusion/tests/test_functions.py
+++ b/python/datafusion/tests/test_functions.py
@@ -963,6 +963,7 @@ def test_first_last_value(df):
     assert result.column(3) == pa.array(["!"])
     assert result.column(4) == pa.array([6])
     assert result.column(5) == pa.array([datetime(2020, 7, 2)])
+    df.show()
 
 
 def test_binary_string_functions(df):

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -39,6 +39,7 @@ use pyo3::types::{PyCapsule, PyTuple};
 use tokio::task::JoinHandle;
 
 use crate::errors::py_datafusion_err;
+use crate::expr::to_sort_expressions;
 use crate::physical_plan::PyExecutionPlan;
 use crate::record_batch::PyRecordBatchStream;
 use crate::sql::logical::PyLogicalPlan;
@@ -150,7 +151,7 @@ impl PyDataFrame {
 
     #[pyo3(signature = (*exprs))]
     fn sort(&self, exprs: Vec<PyExpr>) -> PyResult<Self> {
-        let exprs = exprs.into_iter().map(|e| e.into()).collect();
+        let exprs = to_sort_expressions(exprs);
         let df = self.df.as_ref().clone().sort(exprs)?;
         Ok(Self::new(df))
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -519,8 +519,10 @@ impl PyExpr {
     // Expression Function Builder functions
 
     pub fn order_by(&self, order_by: Vec<PyExpr>) -> PyExprFuncBuilder {
-        let order_by = order_by.iter().map(|e| e.expr.clone()).collect();
-        self.expr.clone().order_by(order_by).into()
+        self.expr
+            .clone()
+            .order_by(to_sort_expressions(order_by))
+            .into()
     }
 
     pub fn filter(&self, filter: PyExpr) -> PyExprFuncBuilder {
@@ -560,11 +562,24 @@ impl From<ExprFuncBuilder> for PyExprFuncBuilder {
     }
 }
 
+pub fn to_sort_expressions(order_by: Vec<PyExpr>) -> Vec<Expr> {
+    order_by
+        .iter()
+        .map(|e| e.expr.clone())
+        .map(|e| match e {
+            Expr::Sort(_) => e,
+            _ => e.sort(true, true),
+        })
+        .collect()
+}
+
 #[pymethods]
 impl PyExprFuncBuilder {
     pub fn order_by(&self, order_by: Vec<PyExpr>) -> PyExprFuncBuilder {
-        let order_by = order_by.iter().map(|e| e.expr.clone()).collect();
-        self.builder.clone().order_by(order_by).into()
+        self.builder
+            .clone()
+            .order_by(to_sort_expressions(order_by))
+            .into()
     }
 
     pub fn filter(&self, filter: PyExpr) -> PyExprFuncBuilder {

--- a/src/expr/window.rs
+++ b/src/expr/window.rs
@@ -168,7 +168,11 @@ fn not_window_function_err(expr: Expr) -> PyErr {
 impl PyWindowFrame {
     #[new]
     #[pyo3(signature=(unit, start_bound, end_bound))]
-    pub fn new(unit: &str, start_bound: Option<u64>, end_bound: Option<u64>) -> PyResult<Self> {
+    pub fn new(
+        unit: &str,
+        start_bound: Option<ScalarValue>,
+        end_bound: Option<ScalarValue>,
+    ) -> PyResult<Self> {
         let units = unit.to_ascii_lowercase();
         let units = match units.as_str() {
             "rows" => WindowFrameUnits::Rows,
@@ -182,9 +186,7 @@ impl PyWindowFrame {
             }
         };
         let start_bound = match start_bound {
-            Some(start_bound) => {
-                WindowFrameBound::Preceding(ScalarValue::UInt64(Some(start_bound)))
-            }
+            Some(start_bound) => WindowFrameBound::Preceding(start_bound),
             None => match units {
                 WindowFrameUnits::Range => WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
                 WindowFrameUnits::Rows => WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
@@ -197,7 +199,7 @@ impl PyWindowFrame {
             },
         };
         let end_bound = match end_bound {
-            Some(end_bound) => WindowFrameBound::Following(ScalarValue::UInt64(Some(end_bound))),
+            Some(end_bound) => WindowFrameBound::Following(end_bound),
             None => match units {
                 WindowFrameUnits::Rows => WindowFrameBound::Following(ScalarValue::UInt64(None)),
                 WindowFrameUnits::Range => WindowFrameBound::Following(ScalarValue::UInt64(None)),

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -319,18 +319,15 @@ pub fn regr_syy(expr_y: PyExpr, expr_x: PyExpr, distinct: bool) -> PyResult<PyEx
     }
 }
 
-#[pyfunction]
-pub fn first_value(
-    expr: PyExpr,
+fn add_builder_fns_to_aggregate(
+    agg_fn: Expr,
     distinct: bool,
     filter: Option<PyExpr>,
     order_by: Option<Vec<PyExpr>>,
     null_treatment: Option<NullTreatment>,
 ) -> PyResult<PyExpr> {
-    // If we initialize the UDAF with order_by directly, then it gets over-written by the builder
-    let agg_fn = functions_aggregate::expr_fn::first_value(expr.expr, None);
-
-    // luckily, I can guarantee initializing a builder with an `order_by` default of empty vec
+    // Since ExprFuncBuilder::new() is private, we can guarantee initializing
+    // a builder with an `order_by` default of empty vec
     let order_by = order_by
         .map(|x| x.into_iter().map(|x| x.expr).collect::<Vec<_>>())
         .unwrap_or_default();
@@ -351,8 +348,30 @@ pub fn first_value(
 }
 
 #[pyfunction]
-pub fn last_value(expr: PyExpr) -> PyExpr {
-    functions_aggregate::expr_fn::last_value(vec![expr.expr]).into()
+pub fn first_value(
+    expr: PyExpr,
+    distinct: bool,
+    filter: Option<PyExpr>,
+    order_by: Option<Vec<PyExpr>>,
+    null_treatment: Option<NullTreatment>,
+) -> PyResult<PyExpr> {
+    // If we initialize the UDAF with order_by directly, then it gets over-written by the builder
+    let agg_fn = functions_aggregate::expr_fn::first_value(expr.expr, None);
+
+    add_builder_fns_to_aggregate(agg_fn, distinct, filter, order_by, null_treatment)
+}
+
+#[pyfunction]
+pub fn last_value(
+    expr: PyExpr,
+    distinct: bool,
+    filter: Option<PyExpr>,
+    order_by: Option<Vec<PyExpr>>,
+    null_treatment: Option<NullTreatment>,
+) -> PyResult<PyExpr> {
+    let agg_fn = functions_aggregate::expr_fn::last_value(vec![expr.expr]);
+
+    add_builder_fns_to_aggregate(agg_fn, distinct, filter, order_by, null_treatment)
 }
 
 #[pyfunction]

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -872,6 +872,11 @@ pub fn lead(arg: PyExpr, shift_offset: i64, default_value: Option<ScalarValue>) 
     window_function::lead(arg.expr, Some(shift_offset), default_value).into()
 }
 
+#[pyfunction]
+pub fn lag(arg: PyExpr, shift_offset: i64, default_value: Option<ScalarValue>) -> PyExpr {
+    window_function::lag(arg.expr, Some(shift_offset), default_value).into()
+}
+
 pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(abs))?;
     m.add_wrapped(wrap_pyfunction!(acos))?;
@@ -1058,6 +1063,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(flatten))?;
 
     m.add_wrapped(wrap_pyfunction!(lead))?;
+    m.add_wrapped(wrap_pyfunction!(lag))?;
 
     Ok(())
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -24,6 +24,7 @@ use crate::common::data_type::NullTreatment;
 use crate::context::PySessionContext;
 use crate::errors::DataFusionError;
 use crate::expr::conditional_expr::PyCaseBuilder;
+use crate::expr::to_sort_expressions;
 use crate::expr::window::PyWindowFrame;
 use crate::expr::PyExpr;
 use datafusion::execution::FunctionRegistry;
@@ -888,17 +889,7 @@ fn add_builder_fns_to_window(
     }
 
     if let Some(order_by_cols) = order_by {
-        let order_by_cols = order_by_cols
-            .into_iter()
-            .map(|col| {
-                let order_by_expr: Expr = col.into();
-                if let Expr::Sort(_) = order_by_expr {
-                    order_by_expr
-                } else {
-                    order_by_expr.sort(true, true)
-                }
-            })
-            .collect();
+        let order_by_cols = to_sort_expressions(order_by_cols);
         builder = builder.order_by(order_by_cols);
     }
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -887,6 +887,16 @@ pub fn rank() -> PyExpr {
     window_function::rank().into()
 }
 
+#[pyfunction]
+pub fn dense_rank() -> PyExpr {
+    window_function::dense_rank().into()
+}
+
+#[pyfunction]
+pub fn percent_rank() -> PyExpr {
+    window_function::percent_rank().into()
+}
+
 pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(abs))?;
     m.add_wrapped(wrap_pyfunction!(acos))?;
@@ -1076,6 +1086,8 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(lag))?;
     m.add_wrapped(wrap_pyfunction!(row_number))?;
     m.add_wrapped(wrap_pyfunction!(rank))?;
+    m.add_wrapped(wrap_pyfunction!(dense_rank))?;
+    m.add_wrapped(wrap_pyfunction!(percent_rank))?;
 
     Ok(())
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -877,6 +877,11 @@ pub fn lag(arg: PyExpr, shift_offset: i64, default_value: Option<ScalarValue>) -
     window_function::lag(arg.expr, Some(shift_offset), default_value).into()
 }
 
+#[pyfunction]
+pub fn row_number() -> PyExpr {
+    window_function::row_number().into()
+}
+
 pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(abs))?;
     m.add_wrapped(wrap_pyfunction!(acos))?;
@@ -1064,6 +1069,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_wrapped(wrap_pyfunction!(lead))?;
     m.add_wrapped(wrap_pyfunction!(lag))?;
+    m.add_wrapped(wrap_pyfunction!(row_number))?;
 
     Ok(())
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -882,6 +882,11 @@ pub fn row_number() -> PyExpr {
     window_function::row_number().into()
 }
 
+#[pyfunction]
+pub fn rank() -> PyExpr {
+    window_function::rank().into()
+}
+
 pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(abs))?;
     m.add_wrapped(wrap_pyfunction!(acos))?;
@@ -1070,6 +1075,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(lead))?;
     m.add_wrapped(wrap_pyfunction!(lag))?;
     m.add_wrapped(wrap_pyfunction!(row_number))?;
+    m.add_wrapped(wrap_pyfunction!(rank))?;
 
     Ok(())
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -879,7 +879,6 @@ fn add_builder_fns_to_window(
     window_fn: Expr,
     partition_by: Option<Vec<PyExpr>>,
     order_by: Option<Vec<PyExpr>>,
-    null_treatment: Option<NullTreatment>,
 ) -> PyResult<PyExpr> {
     // Since ExprFuncBuilder::new() is private, set an empty partition and then
     // override later if appropriate.
@@ -899,10 +898,6 @@ fn add_builder_fns_to_window(
         builder = builder.order_by(order_by_cols);
     }
 
-    if let Some(null_treatment_val) = null_treatment {
-        builder = builder.null_treatment(Some(null_treatment_val.into()));
-    }
-
     builder.build().map(|e| e.into()).map_err(|err| err.into())
 }
 
@@ -913,11 +908,10 @@ pub fn lead(
     default_value: Option<ScalarValue>,
     partition_by: Option<Vec<PyExpr>>,
     order_by: Option<Vec<PyExpr>>,
-    null_treatment: Option<NullTreatment>,
 ) -> PyResult<PyExpr> {
     let window_fn = window_function::lead(arg.expr, Some(shift_offset), default_value);
 
-    add_builder_fns_to_window(window_fn, partition_by, order_by, null_treatment)
+    add_builder_fns_to_window(window_fn, partition_by, order_by)
 }
 
 #[pyfunction]
@@ -927,66 +921,57 @@ pub fn lag(
     default_value: Option<ScalarValue>,
     partition_by: Option<Vec<PyExpr>>,
     order_by: Option<Vec<PyExpr>>,
-    null_treatment: Option<NullTreatment>,
 ) -> PyResult<PyExpr> {
     let window_fn = window_function::lag(arg.expr, Some(shift_offset), default_value);
 
-    add_builder_fns_to_window(window_fn, partition_by, order_by, null_treatment)
+    add_builder_fns_to_window(window_fn, partition_by, order_by)
 }
 
 #[pyfunction]
 pub fn row_number(
     partition_by: Option<Vec<PyExpr>>,
     order_by: Option<Vec<PyExpr>>,
-    null_treatment: Option<NullTreatment>,
 ) -> PyResult<PyExpr> {
     let window_fn = window_function::row_number();
 
-    add_builder_fns_to_window(window_fn, partition_by, order_by, null_treatment)
+    add_builder_fns_to_window(window_fn, partition_by, order_by)
 }
 
 #[pyfunction]
-pub fn rank(
-    partition_by: Option<Vec<PyExpr>>,
-    order_by: Option<Vec<PyExpr>>,
-    null_treatment: Option<NullTreatment>,
-) -> PyResult<PyExpr> {
+pub fn rank(partition_by: Option<Vec<PyExpr>>, order_by: Option<Vec<PyExpr>>) -> PyResult<PyExpr> {
     let window_fn = window_function::rank();
 
-    add_builder_fns_to_window(window_fn, partition_by, order_by, null_treatment)
+    add_builder_fns_to_window(window_fn, partition_by, order_by)
 }
 
 #[pyfunction]
 pub fn dense_rank(
     partition_by: Option<Vec<PyExpr>>,
     order_by: Option<Vec<PyExpr>>,
-    null_treatment: Option<NullTreatment>,
 ) -> PyResult<PyExpr> {
     let window_fn = window_function::dense_rank();
 
-    add_builder_fns_to_window(window_fn, partition_by, order_by, null_treatment)
+    add_builder_fns_to_window(window_fn, partition_by, order_by)
 }
 
 #[pyfunction]
 pub fn percent_rank(
     partition_by: Option<Vec<PyExpr>>,
     order_by: Option<Vec<PyExpr>>,
-    null_treatment: Option<NullTreatment>,
 ) -> PyResult<PyExpr> {
     let window_fn = window_function::percent_rank();
 
-    add_builder_fns_to_window(window_fn, partition_by, order_by, null_treatment)
+    add_builder_fns_to_window(window_fn, partition_by, order_by)
 }
 
 #[pyfunction]
 pub fn cume_dist(
     partition_by: Option<Vec<PyExpr>>,
     order_by: Option<Vec<PyExpr>>,
-    null_treatment: Option<NullTreatment>,
 ) -> PyResult<PyExpr> {
     let window_fn = window_function::cume_dist();
 
-    add_builder_fns_to_window(window_fn, partition_by, order_by, null_treatment)
+    add_builder_fns_to_window(window_fn, partition_by, order_by)
 }
 
 #[pyfunction]
@@ -994,11 +979,10 @@ pub fn ntile(
     arg: PyExpr,
     partition_by: Option<Vec<PyExpr>>,
     order_by: Option<Vec<PyExpr>>,
-    null_treatment: Option<NullTreatment>,
 ) -> PyResult<PyExpr> {
     let window_fn = window_function::ntile(arg.into());
 
-    add_builder_fns_to_window(window_fn, partition_by, order_by, null_treatment)
+    add_builder_fns_to_window(window_fn, partition_by, order_by)
 }
 
 pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use datafusion::functions_aggregate::all_default_aggregate_functions;
+use datafusion_expr::window_function;
 use datafusion_expr::ExprFunctionExt;
 use pyo3::{prelude::*, wrap_pyfunction};
 
@@ -890,6 +891,11 @@ aggregate_function!(array_agg, functions_aggregate::array_agg::array_agg_udaf);
 aggregate_function!(max, functions_aggregate::min_max::max_udaf);
 aggregate_function!(min, functions_aggregate::min_max::min_udaf);
 
+#[pyfunction]
+pub fn lead(arg: PyExpr, shift_offset: i64, default_value: Option<ScalarValue>) -> PyExpr {
+    window_function::lead(arg.expr, Some(shift_offset), default_value).into()
+}
+
 pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(abs))?;
     m.add_wrapped(wrap_pyfunction!(acos))?;
@@ -1074,6 +1080,8 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(array_sort))?;
     m.add_wrapped(wrap_pyfunction!(array_slice))?;
     m.add_wrapped(wrap_pyfunction!(flatten))?;
+
+    m.add_wrapped(wrap_pyfunction!(lead))?;
 
     Ok(())
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -897,6 +897,11 @@ pub fn percent_rank() -> PyExpr {
     window_function::percent_rank().into()
 }
 
+#[pyfunction]
+pub fn cume_dist() -> PyExpr {
+    window_function::cume_dist().into()
+}
+
 pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(abs))?;
     m.add_wrapped(wrap_pyfunction!(acos))?;
@@ -1088,6 +1093,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(rank))?;
     m.add_wrapped(wrap_pyfunction!(dense_rank))?;
     m.add_wrapped(wrap_pyfunction!(percent_rank))?;
+    m.add_wrapped(wrap_pyfunction!(cume_dist))?;
 
     Ok(())
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -902,6 +902,11 @@ pub fn cume_dist() -> PyExpr {
     window_function::cume_dist().into()
 }
 
+#[pyfunction]
+pub fn ntile(arg: PyExpr) -> PyExpr {
+    window_function::ntile(arg.into()).into()
+}
+
 pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(abs))?;
     m.add_wrapped(wrap_pyfunction!(acos))?;
@@ -1087,6 +1092,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(array_slice))?;
     m.add_wrapped(wrap_pyfunction!(flatten))?;
 
+    // Window Functions
     m.add_wrapped(wrap_pyfunction!(lead))?;
     m.add_wrapped(wrap_pyfunction!(lag))?;
     m.add_wrapped(wrap_pyfunction!(row_number))?;
@@ -1094,6 +1100,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(dense_rank))?;
     m.add_wrapped(wrap_pyfunction!(percent_rank))?;
     m.add_wrapped(wrap_pyfunction!(cume_dist))?;
+    m.add_wrapped(wrap_pyfunction!(ntile))?;
 
     Ok(())
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -349,32 +349,8 @@ pub fn first_value(
 }
 
 #[pyfunction]
-pub fn last_value(
-    expr: PyExpr,
-    distinct: bool,
-    filter: Option<PyExpr>,
-    order_by: Option<Vec<PyExpr>>,
-    null_treatment: Option<NullTreatment>,
-) -> PyResult<PyExpr> {
-    let agg_fn = functions_aggregate::expr_fn::last_value(vec![expr.expr]);
-
-    // luckily, I can guarantee initializing a builder with an `order_by` default of empty vec
-    let order_by = order_by
-        .map(|x| x.into_iter().map(|x| x.expr).collect::<Vec<_>>())
-        .unwrap_or_default();
-    let mut builder = agg_fn.order_by(order_by);
-
-    if distinct {
-        builder = builder.distinct();
-    }
-
-    if let Some(filter) = filter {
-        builder = builder.filter(filter.expr);
-    }
-
-    builder = builder.null_treatment(null_treatment.map(DFNullTreatment::from));
-
-    Ok(builder.build()?.into())
+pub fn last_value(expr: PyExpr) -> PyExpr {
+    functions_aggregate::expr_fn::last_value(vec![expr.expr]).into()
 }
 
 #[pyfunction]


### PR DESCRIPTION
# Which issue does this PR close?

This addresses part of #780 but we need a follow on PR to handle the aggregates.

 # Rationale for this change

In DataFusion 41 we have added the ability to create builders for the parameters for window and aggregate functions. These are more expressive when it comes to setting the window frame, ordering, partition, and null handling. This MR exposes this functionality on the python side.

# What changes are included in this PR?

Added functions
- lead
- lag
- row_number
- rank
- dense_rank
- percent_rank
- cume_dist
- ntile

Also updated the window function page of the online documentation to include links to these, examples of how to use them, and a description of how to set the additional parameters.

Updated the unit tests.

# Are there any user-facing changes?

There are no breaking changes, but the old functions.window has been marked as deprecated. We can change this if needed because it is currently the only way to use aggregate functions as window functions. That is to be addressed in #833