### PR TITLE
Add PyCapsule support for Arrow import and export

### DIFF
--- a/docs/source/user-guide/io/arrow.rst
+++ b/docs/source/user-guide/io/arrow.rst
@@ -1,0 +1,71 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+Arrow
+=====
+
+DataFusion implements the 
+`Apache Arrow PyCapsule interface <https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html>`_
+for importing and exporting DataFrames with zero copy. With this feature, any Python
+project that implements this interface can share data back and forth with DataFusion
+with zero copy.
+
+We can demonstrate using `pyarrow <https://arrow.apache.org/docs/python/index.html>`_.
+
+Importing to DataFusion
+-----------------------
+
+Here we will create an Arrow table and import it to DataFusion.
+
+To import an Arrow table, use :py:func:`datafusion.context.SessionContext.from_arrow`.
+This will accept any Python object that implements
+`__arrow_c_stream__ <https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html#arrowstream-export>`_
+or `__arrow_c_array__ <https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html#arrowarray-export>`_
+and returns a ``StructArray``. Common pyarrow sources you can use are:
+
+- `Array <https://arrow.apache.org/docs/python/generated/pyarrow.Array.html>`_ (but it must return a Struct Array)
+- `Record Batch <https://arrow.apache.org/docs/python/generated/pyarrow.RecordBatch.html>`_
+- `Record Batch Reader <https://arrow.apache.org/docs/python/generated/pyarrow.RecordBatchReader.html>`_
+- `Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`_
+
+.. ipython:: python
+
+    from datafusion import SessionContext
+    import pyarrow as pa
+
+    data = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    table = pa.Table.from_pydict(data)
+
+    ctx = SessionContext()
+    df = ctx.from_arrow(table)
+    df
+
+Exporting from DataFusion
+-------------------------
+
+DataFusion DataFrames implement ``__arrow_c_stream__`` PyCapsule interface, so any
+Python library that accepts these can import a DataFusion DataFrame directly. It is
+important to note that this will cause the DataFrame execution to happen, which may be
+a time consuming task. That is, you will cause a :py:func:`datafusion.dataframe.DataFrame.collect`
+operation call to occur.
+
+
+.. ipython:: python
+
+    df = df.select((col("a") * lit(1.5)).alias("c"), lit("df").alias("d"))
+    pa.table(df)
+

--- a/docs/source/user-guide/io/arrow.rst
+++ b/docs/source/user-guide/io/arrow.rst
@@ -18,7 +18,7 @@
 Arrow
 =====
 
-DataFusion implements the 
+DataFusion implements the
 `Apache Arrow PyCapsule interface <https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html>`_
 for importing and exporting DataFrames with zero copy. With this feature, any Python
 project that implements this interface can share data back and forth with DataFusion
@@ -58,10 +58,12 @@ Exporting from DataFusion
 -------------------------
 
 DataFusion DataFrames implement ``__arrow_c_stream__`` PyCapsule interface, so any
-Python library that accepts these can import a DataFusion DataFrame directly. It is
-important to note that this will cause the DataFrame execution to happen, which may be
-a time consuming task. That is, you will cause a :py:func:`datafusion.dataframe.DataFrame.collect`
-operation call to occur.
+Python library that accepts these can import a DataFusion DataFrame directly.
+
+.. warning::
+    It is important to note that this will cause the DataFrame execution to happen, which may be
+    a time consuming task. That is, you will cause a
+    :py:func:`datafusion.dataframe.DataFrame.collect` operation call to occur.
 
 
 .. ipython:: python

--- a/docs/source/user-guide/io/index.rst
+++ b/docs/source/user-guide/io/index.rst
@@ -21,8 +21,8 @@ IO
 .. toctree::
    :maxdepth: 2
 
-   csv
-   parquet
-   json
+   arrow
    avro
-
+   csv
+   json
+   parquet

--- a/examples/import.py
+++ b/examples/import.py
@@ -54,5 +54,5 @@ assert type(df) == datafusion.DataFrame
 
 # Convert Arrow Table to datafusion DataFrame
 arrow_table = pa.Table.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
-df = ctx.from_arrow_table(arrow_table)
+df = ctx.from_arrow(arrow_table)
 assert type(df) == datafusion.DataFrame

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -586,19 +586,30 @@ class SessionContext:
         """
         return DataFrame(self.ctx.from_pydict(data, name))
 
-    def from_arrow_table(
-        self, data: pyarrow.Table, name: str | None = None
-    ) -> DataFrame:
-        """Create a :py:class:`~datafusion.dataframe.DataFrame` from an Arrow table.
+    def from_arrow(self, data: Any, name: str | None = None) -> DataFrame:
+        """Create a :py:class:`~datafusion.dataframe.DataFrame` from an Arrow source.
+
+        The Arrow data source can be any object that implements either
+        ``__arrow_c_stream__`` or ``__arrow_c_array__``. For the latter, it must return
+        a struct array. Common examples of sources from pyarrow include
 
         Args:
-            data: Arrow table.
+            data: Arrow data source.
             name: Name of the DataFrame.
 
         Returns:
             DataFrame representation of the Arrow table.
         """
-        return DataFrame(self.ctx.from_arrow_table(data, name))
+        return DataFrame(self.ctx.from_arrow(data, name))
+
+    def from_arrow_table(
+        self, data: pyarrow.Table, name: str | None = None
+    ) -> DataFrame:
+        """Create a :py:class:`~datafusion.dataframe.DataFrame` from an Arrow table.
+
+        This is an alias for :py:func:`from_arrow`.
+        """
+        return self.from_arrow(data, name)
 
     def from_pandas(self, data: pandas.DataFrame, name: str | None = None) -> DataFrame:
         """Create a :py:class:`~datafusion.dataframe.DataFrame` from a Pandas DataFrame.

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -602,6 +602,7 @@ class SessionContext:
         """
         return DataFrame(self.ctx.from_arrow(data, name))
 
+    @deprecated("Use ``from_arrow`` instead.")
     def from_arrow_table(
         self, data: pyarrow.Table, name: str | None = None
     ) -> DataFrame:

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -524,3 +524,19 @@ class DataFrame:
         """
         columns = [c for c in columns]
         return DataFrame(self.df.unnest_columns(columns, preserve_nulls=preserve_nulls))
+
+    def __arrow_c_stream__(self, requested_schema: pa.Schema) -> Any:
+        """Export an Arrow PyCapsule Stream.
+
+        This will execute and collect the DataFrame. We will attempt to respect the
+        requested schema, but only trivial transformations will be applied such as only
+        returning the fields listed in the requested schema if their data types match
+        those in the DataFrame.
+
+        Args:
+            requested_schema: Attempt to provide the DataFrame using this schema.
+
+        Returns:
+            Arrow PyCapsule object.
+        """
+        return self.df.__arrow_c_stream__(requested_schema)

--- a/python/datafusion/tests/test_context.py
+++ b/python/datafusion/tests/test_context.py
@@ -156,7 +156,7 @@ def test_from_arrow_table(ctx):
     table = pa.Table.from_pydict(data)
 
     # convert to DataFrame
-    df = ctx.from_arrow_table(table)
+    df = ctx.from_arrow(table)
     tables = list(ctx.catalog().database().names())
 
     assert df
@@ -202,7 +202,7 @@ def test_from_arrow_table_with_name(ctx):
     table = pa.Table.from_pydict(data)
 
     # convert to DataFrame with optional name
-    df = ctx.from_arrow_table(table, name="tbl")
+    df = ctx.from_arrow(table, name="tbl")
     tables = list(ctx.catalog().database().names())
 
     assert df
@@ -215,7 +215,7 @@ def test_from_arrow_table_empty(ctx):
     table = pa.Table.from_pydict(data, schema=schema)
 
     # convert to DataFrame
-    df = ctx.from_arrow_table(table)
+    df = ctx.from_arrow(table)
     tables = list(ctx.catalog().database().names())
 
     assert df
@@ -230,7 +230,7 @@ def test_from_arrow_table_empty_no_schema(ctx):
     table = pa.Table.from_pydict(data)
 
     # convert to DataFrame
-    df = ctx.from_arrow_table(table)
+    df = ctx.from_arrow(table)
     tables = list(ctx.catalog().database().names())
 
     assert df

--- a/python/datafusion/tests/test_context.py
+++ b/python/datafusion/tests/test_context.py
@@ -166,7 +166,6 @@ def test_from_arrow_table(ctx):
     assert df.collect()[0].num_rows == 3
 
 
-@pytest.mark.skip
 def record_batch_generator(num_batches: int):
     schema = pa.schema([("a", pa.int64()), ("b", pa.int64())])
     for i in range(num_batches):

--- a/python/datafusion/tests/test_context.py
+++ b/python/datafusion/tests/test_context.py
@@ -166,6 +166,21 @@ def test_from_arrow_table(ctx):
     assert df.collect()[0].num_rows == 3
 
 
+def test_from_arrow_record_batch_reader(ctx) -> None:
+    schema = pa.schema([("a", pa.int64())])
+
+    def iter_record_batches():
+        for i in range(2):
+            yield pa.RecordBatch.from_arrays([pa.array([1, 2, 3])], schema=schema)
+
+    reader = pa.RecordBatchReader.from_batches(schema, iter_record_batches())
+    df = ctx.from_arrow_table(reader)
+    assert df
+    assert isinstance(df, DataFrame)
+    assert df.schema().names == ["a"]
+    assert df.count() == 6
+
+
 def test_from_arrow_table_with_name(ctx):
     # create a PyArrow table
     data = {"a": [1, 2, 3], "b": [4, 5, 6]}

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -47,7 +47,7 @@ def df():
         names=["a", "b", "c"],
     )
 
-    return ctx.create_dataframe([[batch]])
+    return ctx.from_arrow(batch)
 
 
 @pytest.fixture

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -836,19 +836,11 @@ def test_write_compressed_parquet_missing_compression_level(df, tmp_path, compre
 
 
 def test_dataframe_export(df) -> None:
-    import nanoarrow
-
     # Guarantees that we have the canonical implementation
     # reading our dataframe export
     table = pa.table(df)
     assert table.num_columns == 3
     assert table.num_rows == 3
-
-    # nanoarrow is an independent library that should also be
-    # able to import our dataframe
-    table = nanoarrow.Array(df)
-    assert len(table) == 3
-    assert len(table[0].as_py()) == 3
 
     desired_schema = pa.schema([("a", pa.int64())])
 

--- a/python/datafusion/tests/test_dataframe.py
+++ b/python/datafusion/tests/test_dataframe.py
@@ -835,13 +835,50 @@ def test_write_compressed_parquet_missing_compression_level(df, tmp_path, compre
         df.write_parquet(str(path), compression=compression)
 
 
-# ctx = SessionContext()
+def test_dataframe_export(df) -> None:
+    import nanoarrow
 
-# # create a RecordBatch and a new DataFrame from it
-# batch = pa.RecordBatch.from_arrays(
-#     [pa.array([1, 2, 3]), pa.array([4, 5, 6]), pa.array([8, 5, 8])],
-#     names=["a", "b", "c"],
-# )
+    # Guarantees that we have the canonical implementation
+    # reading our dataframe export
+    table = pa.table(df)
+    assert table.num_columns == 3
+    assert table.num_rows == 3
 
-# df = ctx.create_dataframe([[batch]])
-# test_execute_stream(df)
+    # nanoarrow is an independent library that should also be
+    # able to import our dataframe
+    table = nanoarrow.Array(df)
+    assert len(table) == 3
+    assert len(table[0].as_py()) == 3
+
+    desired_schema = pa.schema([("a", pa.int64())])
+
+    # Verify we can request a schema
+    table = pa.table(df, schema=desired_schema)
+    assert table.num_columns == 1
+    assert table.num_rows == 3
+
+    # Expect a table of nulls if the schema don't overlap
+    desired_schema = pa.schema([("g", pa.string())])
+    table = pa.table(df, schema=desired_schema)
+    assert table.num_columns == 1
+    assert table.num_rows == 3
+    for i in range(0, 3):
+        assert table[0][i].as_py() is None
+
+    # Expect an error when we cannot convert schema
+    desired_schema = pa.schema([("a", pa.float32())])
+    failed_convert = False
+    try:
+        table = pa.table(df, schema=desired_schema)
+    except Exception:
+        failed_convert = True
+    assert failed_convert
+
+    # Expect an error when we have a not set non-nullable
+    desired_schema = pa.schema([("g", pa.string(), False)])
+    failed_convert = False
+    try:
+        table = pa.table(df, schema=desired_schema)
+    except Exception:
+        failed_convert = True
+    assert failed_convert

--- a/src/context.rs
+++ b/src/context.rs
@@ -447,7 +447,7 @@ impl PySessionContext {
         let table = table_class.call_method1("from_pylist", args)?;
 
         // Convert Arrow Table to datafusion DataFrame
-        let df = self.from_arrow_table(table, name, py)?;
+        let df = self.from_arrow(table, name, py)?;
         Ok(df)
     }
 
@@ -466,12 +466,12 @@ impl PySessionContext {
         let table = table_class.call_method1("from_pydict", args)?;
 
         // Convert Arrow Table to datafusion DataFrame
-        let df = self.from_arrow_table(table, name, py)?;
+        let df = self.from_arrow(table, name, py)?;
         Ok(df)
     }
 
     /// Construct datafusion dataframe from Arrow Table
-    pub fn from_arrow_table(
+    pub fn from_arrow(
         &mut self,
         data: Bound<'_, PyAny>,
         name: Option<&str>,
@@ -520,7 +520,7 @@ impl PySessionContext {
         let table = table_class.call_method1("from_pandas", args)?;
 
         // Convert Arrow Table to datafusion DataFrame
-        let df = self.from_arrow_table(table, name, py)?;
+        let df = self.from_arrow(table, name, py)?;
         Ok(df)
     }
 
@@ -534,7 +534,7 @@ impl PySessionContext {
         let table = data.call_method0("to_arrow")?;
 
         // Convert Arrow Table to datafusion DataFrame
-        let df = self.from_arrow_table(table, name, data.py())?;
+        let df = self.from_arrow(table, name, data.py())?;
         Ok(df)
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -20,10 +20,10 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use datafusion::execution::session_state::SessionStateBuilder;
 use arrow::array::RecordBatchReader;
 use arrow::ffi_stream::ArrowArrayStreamReader;
 use arrow::pyarrow::FromPyArrow;
+use datafusion::execution::session_state::SessionStateBuilder;
 use object_store::ObjectStore;
 use url::Url;
 use uuid::Uuid;

--- a/src/context.rs
+++ b/src/context.rs
@@ -483,7 +483,7 @@ impl PySessionContext {
 
                 let schema = stream_reader.schema().as_ref().to_owned();
                 let batches = stream_reader
-                    .collect::<std::result::Result<Vec<RecordBatch>, arrow::error::ArrowError>>()
+                    .collect::<Result<Vec<RecordBatch>, arrow::error::ArrowError>>()
                     .map_err(DataFusionError::from)?;
 
                 (schema, batches)

--- a/src/context.rs
+++ b/src/context.rs
@@ -489,7 +489,7 @@ impl PySessionContext {
                 (schema, batches)
             } else if let Ok(array) = RecordBatch::from_pyarrow_bound(&data) {
                 // While this says RecordBatch, it will work for any object that implements
-                // __arrow_c_array__ in pycapsule.
+                // __arrow_c_array__ and returns a StructArray.
 
                 (array.schema().as_ref().to_owned(), vec![array])
             } else {

--- a/src/context.rs
+++ b/src/context.rs
@@ -494,7 +494,7 @@ impl PySessionContext {
                 (array.schema().as_ref().to_owned(), vec![array])
             } else {
                 return Err(PyTypeError::new_err(
-                    "Expected either a Arrow Array or Arrow Stream in from_arrow_table().",
+                    "Expected either a Arrow Array or Arrow Stream in from_arrow().",
                 ));
             };
 

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -23,7 +23,6 @@ use arrow::compute::can_cast_types;
 use arrow::error::ArrowError;
 use arrow::ffi::FFI_ArrowSchema;
 use arrow::ffi_stream::FFI_ArrowArrayStream;
-use arrow::pyarrow::FromPyArrow;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::pyarrow::{PyArrowType, ToPyArrow};
 use datafusion::arrow::util::pretty;

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -471,17 +471,16 @@ impl PyDataFrame {
             let schema_ptr = unsafe { schema_capsule.reference::<FFI_ArrowSchema>() };
             let desired_schema = Schema::try_from(schema_ptr).map_err(DataFusionError::from)?;
 
-            schema = project_schema(schema, desired_schema)
-                .map_err(|e| DataFusionError::ArrowError(e))?;
+            schema = project_schema(schema, desired_schema).map_err(DataFusionError::ArrowError)?;
 
             batches = batches
                 .into_iter()
                 .map(|record_batch| record_batch_into_schema(record_batch, &schema))
                 .collect::<Result<Vec<RecordBatch>, ArrowError>>()
-                .map_err(|e| DataFusionError::ArrowError(e))?;
+                .map_err(DataFusionError::ArrowError)?;
         }
 
-        let batches_wrapped = batches.into_iter().map(|r| Ok(r));
+        let batches_wrapped = batches.into_iter().map(Ok);
 
         let reader = RecordBatchIterator::new(batches_wrapped, Arc::new(schema));
         let reader: Box<dyn RecordBatchReader + Send> = Box::new(reader);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #752 

 # Rationale for this change

User requested.

# What changes are included in this PR?

With this change you can import any arrow table that implements the PyCapsule Interface using the `SessionContext.from_arrow_table` function. Additionally, PyCapsule export of DataFrame is added. Now any python based project that uses python arrow with the pycapsule interface can directly consume a datafusion dataframe.

The DataFrame will be executed at the point of export.

You can see a minimal example in the issue ticket.

# Are there any user-facing changes?

This PR adds `SessionContext.from_arrow` which served the same purpose as `from_arrow_table` except that it now takes any object that implements the required PyCapsule functions. `from_arrow_table` is now an alias to `from_arrow`.

# Still to do:

- [x] Add support for the requested schema
- [x] Add user examples
- [x] Add unit tests
