### PR TITLE
Fix SessionContext init with only SessionConfig

### DIFF
--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -445,7 +445,7 @@ class SessionContext:
             df = ctx.read_csv("data.csv")
         """
         config = config.config_internal if config is not None else None
-        runtime = runtime.config_internal if config is not None else None
+        runtime = runtime.config_internal if runtime is not None else None
 
         self.ctx = SessionContextInternal(config, runtime)
 

--- a/python/datafusion/tests/test_context.py
+++ b/python/datafusion/tests/test_context.py
@@ -38,6 +38,14 @@ def test_create_context_no_args():
     SessionContext()
 
 
+def test_create_context_session_config_only():
+    SessionContext(config=SessionConfig())
+
+
+def test_create_context_runtime_config_only():
+    SessionContext(runtime=RuntimeConfig())
+
+
 @pytest.mark.parametrize("path_to_str", (True, False))
 def test_runtime_configs(tmp_path, path_to_str):
     path1 = tmp_path / "dir1"


### PR DESCRIPTION
Previously creating a `SessionContext` when specifying only a `SessionConfig` would error.

Fixes #826.