### PR TITLE
build(deps): upgrade actions/{upload,download}-artifact@v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
 
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-wheel-license
           path: .
@@ -145,7 +145,7 @@ jobs:
 
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-wheel-license
           path: .
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-wheel-license
           path: .
@@ -204,7 +204,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-wheel-license
           path: .
@@ -234,7 +234,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-wheel-license
           path: .
@@ -258,7 +258,7 @@ jobs:
   #   needs: [build-manylinux, build-python-mac-win]
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/download-artifact@v3
+  #     - uses: actions/download-artifact@v4
   #     - name: Publish to PyPI
   #       uses: pypa/gh-action-pypi-publish@master
   #       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           override: true
       - name: Generate license file
         run: python ./dev/create_license.py
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: python-wheel-license
           path: LICENSE.txt
@@ -110,7 +110,7 @@ jobs:
         run: find target/wheels/
 
       - name: Archive wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: target/wheels/*
@@ -162,7 +162,7 @@ jobs:
         run: find target/wheels/
 
       - name: Archive wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: target/wheels/*
@@ -191,7 +191,7 @@ jobs:
           rustup-components: rust-std rustfmt # Keep them in one line due to https://github.com/PyO3/maturin-action/issues/153
           args: --release --manylinux 2014 --features protoc,substrait
       - name: Archive wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: target/wheels/*
@@ -221,7 +221,7 @@ jobs:
           rustup-components: rust-std rustfmt # Keep them in one line due to https://github.com/PyO3/maturin-action/issues/153
           args: --release --features protoc,substrait
       - name: Archive wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: target/wheels/*
@@ -247,7 +247,7 @@ jobs:
           rustup-components: rust-std rustfmt
           args: --release --sdist --out dist --features protoc,substrait
       - name: Archive wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: target/wheels/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: dist-mac-win
+          name: dist-${{ matrix.os  }}
           path: target/wheels/*
 
   build-macos-aarch64:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-mac-win
           path: target/wheels/*
 
   build-macos-aarch64:
@@ -164,7 +164,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-macos-aarch64
           path: target/wheels/*
 
   build-manylinux:
@@ -193,7 +193,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-manylinux
           path: target/wheels/*
 
   build-manylinux-aarch64:
@@ -223,7 +223,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-manylinux-aarch64
           path: target/wheels/*
 
   build-sdist:
@@ -249,9 +249,24 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-sdist
           path: target/wheels/*
-
+  
+  merge-build-artifacts:
+    runs-on: ubuntu-latest
+    needs:
+      - build-python-mac-win
+      - build-macos-aarch64
+      - build-manylinux
+      - build-manylinux-aarch64
+      - build-sdist
+    steps:
+      - name: Merge Build Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: dist
+          pattern: dist-*
+  
   # NOTE: PyPI publish needs to be done manually for now after release passed the vote
   # release:
   #   name: Publish in PyPI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
           name: dist-macos-aarch64
           path: target/wheels/*
 
-  build-manylinux:
+  build-manylinux-x86_64:
     needs: [generate-license]
     name: Manylinux
     runs-on: ubuntu-latest
@@ -193,7 +193,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: dist-manylinux
+          name: dist-manylinux-x86_64
           path: target/wheels/*
 
   build-manylinux-aarch64:
@@ -246,18 +246,22 @@ jobs:
           manylinux: auto
           rustup-components: rust-std rustfmt
           args: --release --sdist --out dist --features protoc,substrait
-      - name: Archive wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist-sdist
-          path: target/wheels/*
+      - name: Assert sdist build does not generate wheels
+        run: |
+            if [ "$(ls -A target/wheels)" ]; then
+              echo "Error: Sdist build generated wheels"
+              exit 1
+            else
+              echo "Directory is clean"
+            fi
+        shell: bash
   
   merge-build-artifacts:
     runs-on: ubuntu-latest
     needs:
       - build-python-mac-win
       - build-macos-aarch64
-      - build-manylinux
+      - build-manylinux-x86_64
       - build-manylinux-aarch64
       - build-sdist
     steps:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           conda mambabuild --test packages/${{ matrix.arch }}/*.tar.bz2
       - name: Upload conda packages as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "conda nightlies (python - ${{ matrix.python }}, arch - ${{ matrix.arch }})"
           # need to install all conda channel metadata to properly install locally


### PR DESCRIPTION
> [!NOTE]
> The text of the PR has undergone significant changes since this morning on 2024-08-22. I noticed and tracked down some bugs in the build behavior that existed prior to this PR but went unnoticed. The result of that investigation is the two follow-on issues at the end.

# Which issue does this PR close?

Closes #724.

 # Rationale for this change

v3 will be disabled [2024-11-30](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

The change between `actions/upload-artifact@v3` and `v4` that impacted us was that each artifact is now immutable.

With v3, a wheel would be built for each target platform and then uploaded to the same `dist` artifact, which would aggregate the artifacts in an archive.

With v4, all but the 1st attempt to upload to `dist` fails with [this error](https://github.com/apache/datafusion-python/actions/runs/10501320879/job/29091137323)

> Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

# What changes are included in this PR?

To achieve this same behavior with v4, each build target must upload to its own unique key before merging them as a final step, as suggested in the [migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#merging-multiple-artifacts).

Although the build workflow now produces a `dist-*` artifact for each build target, the final merged `dist.zip` artifact has the same structure as before. 

> [!WARNING]
> Notice `build.yml` workflow *should* create 6 artifacts, but both `dist.zip`'s only contain 4 artifacts. See Additional Context at end. 

**[Build Summary from 40.1.0 release](https://github.com/apache/datafusion-python/actions/runs/10413095890)**

```console
❯ unzip -- -l dist.zip
Archive:  dist.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
 15145056  08-16-2024 01:38   datafusion-40.1.0-cp38-abi3-macosx_11_0_arm64.whl
 18462692  08-16-2024 01:41   datafusion-40.1.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 17550315  08-16-2024 01:41   datafusion-40.1.0-cp38-abi3-manylinux_2_28_aarch64.whl
 17850348  08-16-2024 01:48   datafusion-40.1.0-cp38-abi3-win_amd64.whl
---------                     -------
 69008411                     4 files
```

**[Build Summary from this PR](https://github.com/apache/datafusion-python/actions/runs/10501567861)**

```console
❯ unzip -- -l dist.zip
Archive:  dist.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
 15158055  08-22-2024 04:21   datafusion-40.0.0-cp38-abi3-macosx_11_0_arm64.whl
 18469550  08-22-2024 04:21   datafusion-40.0.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 17566025  08-22-2024 04:21   datafusion-40.0.0-cp38-abi3-manylinux_2_28_aarch64.whl
 17862321  08-22-2024 04:21   datafusion-40.0.0-cp38-abi3-win_amd64.whl
---------                     -------
 69055951                     4 files
```

# Are there any user-facing changes?

There shouldn't be.

# Additional Context

This PR upgrades the action while maintaining current behavior. I assume we'll want a follow-on PR to address the two following warnings.

- #831 
- #832