### PR TITLE
build(ci): use proper mac runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,7 @@ jobs:
 
   build-manylinux-x86_64:
     needs: [generate-license]
-    name: Manylinux
+    name: Manylinux x86_64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,10 +115,10 @@ jobs:
           name: dist-${{ matrix.os  }}
           path: target/wheels/*
 
-  build-macos-aarch64:
+  build-macos-x86_64:
     needs: [generate-license]
     name: Mac arm64
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:
@@ -133,9 +133,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-
-      - name: Set up Rust targets
-        run: rustup target add aarch64-apple-darwin
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
@@ -157,7 +154,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Python package
-        run: maturin build --release --strip --target aarch64-apple-darwin --features substrait
+        run: maturin build --release --strip --features substrait
       - name: List Mac wheels
         run: find target/wheels/
 
@@ -260,7 +257,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-python-mac-win
-      - build-macos-aarch64
+      - build-macos-x86_64
       - build-manylinux-x86_64
       - build-manylinux-aarch64
       - build-sdist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
 
   build-macos-x86_64:
     needs: [generate-license]
-    name: Mac arm64
+    name: Mac x86_64
     runs-on: macos-13
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Which issue does this PR close?

Closes #831
 # Rationale for this change
GH updated the runner images.

macos-14 is now ARM64.
macos-13 is last x86_64.

# What changes are included in this PR?
The build steps for `mac` have been updated.

This fix means we actually get a build wheel for `x86_64` on `macos`.

Example the `dist.zip` [this build](https://github.com/apache/datafusion-python/actions/runs/10567528280):

```console
unzip -- -l dist.zip
Archive:  dist.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
 17180608  08-26-2024 21:49   datafusion-40.0.0-cp38-abi3-macosx_10_12_x86_64.whl
 15600059  08-26-2024 21:49   datafusion-40.0.0-cp38-abi3-macosx_11_0_arm64.whl
 19048084  08-26-2024 21:49   datafusion-40.0.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 18111348  08-26-2024 21:49   datafusion-40.0.0-cp38-abi3-manylinux_2_28_aarch64.whl
 18464214  08-26-2024 21:49   datafusion-40.0.0-cp38-abi3-win_amd64.whl
---------                     -------
 88404313                     5 files
```

# Are there any user-facing changes?
No.