### PR TITLE
build(deps): upgrade setup-protoc action and protoc version number

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,9 +92,9 @@ jobs:
           path: .
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
-          version: "3.20.2"
+          version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Python package
@@ -150,9 +150,9 @@ jobs:
           path: .
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
-          version: "3.20.2"
+          version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Python package

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -52,9 +52,9 @@ jobs:
           python-version: "3.11"
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
-          version: '3.20.2'
+          version: '27.4'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,9 +50,9 @@ jobs:
           override: true
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
-          version: '3.20.2'
+          version: '27.4'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python


### PR DESCRIPTION
# Which issue does this PR close?

Closes #578.
(Really, supersedes that PR).

 # Rationale for this change

Bumping this GH Action dependency is the last active `dependabot` PR.

`arduino/setup-protoc@v3` could not find our old version number of `3.20.2`.

I chose `protoc` [version 27.4](https://github.com/protocolbuffers/protobuf/releases/tag/v27.4) because it's the last release from the prior version.

# What changes are included in this PR?

`arduino/setup-protoc` action is updated from v1 to v3.

`protoc` version is updated from `3.20.2` to `27.4`.

# Are there any user-facing changes?

There should not be.