### PR TITLE
feat: make register_csv accept a list of paths

### DIFF
--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -714,7 +714,7 @@ class SessionContext:
     def register_csv(
         self,
         name: str,
-        path: str | pathlib.Path,
+        path: str | pathlib.Path | list[str | pathlib.Path],
         schema: pyarrow.Schema | None = None,
         has_header: bool = True,
         delimiter: str = ",",
@@ -728,7 +728,7 @@ class SessionContext:
 
         Args:
             name: Name of the table to register.
-            path: Path to the CSV file.
+            path: Path to the CSV file. It also accepts a list of Paths.
             schema: An optional schema representing the CSV file. If None, the
                 CSV reader will try to infer it based on data in file.
             has_header: Whether the CSV file have a header. If schema inference
@@ -741,9 +741,14 @@ class SessionContext:
                 selected for data input.
             file_compression_type: File compression type.
         """
+        if isinstance(path, list):
+            path = [str(p) for p in path]
+        else:
+            path = str(path)
+
         self.ctx.register_csv(
             name,
-            str(path),
+            path,
             schema,
             has_header,
             delimiter,


### PR DESCRIPTION
# Which issue does this PR close?
N/A

# Rationale for this change
The method `read_csv` accepts a list of paths as input. It seems fitting that `register_csv` does the same. Moreover, it will solve the issue behind https://github.com/ibis-project/ibis/issues/9866.

# Rationale for this change
Enable users to supply a list of csv file paths to the `register_csv` function.

# What changes are included in this PR?
Changes to the `register_csv` function in Rust and the corresponding signature types in Python 

# Are there any user-facing changes?
Yes