### PR TITLE
chore: remove XFAIL from passing tests

### DIFF
--- a/python/datafusion/tests/test_sql.py
+++ b/python/datafusion/tests/test_sql.py
@@ -378,22 +378,26 @@ _null_mask = np.array([False, True, False])
         helpers.data_binary_other(),
         helpers.data_date32(),
         helpers.data_with_nans(),
-        # C data interface missing
         pytest.param(
             pa.array([b"1111", b"2222", b"3333"], pa.binary(4), _null_mask),
             id="binary4",
         ),
         pytest.param(
-            helpers.data_datetime("s"), id="datetime_s", marks=pytest.mark.xfail
+            helpers.data_datetime("s"),
+            id="datetime_s",
+            marks=pytest.mark.xfail(reason="Mismatch in format"),
         ),
         pytest.param(
-            helpers.data_datetime("ms"), id="datetime_ms",
+            helpers.data_datetime("ms"),
+            id="datetime_ms",
         ),
         pytest.param(
-            helpers.data_datetime("us"), id="datetime_us",
+            helpers.data_datetime("us"),
+            id="datetime_us",
         ),
         pytest.param(
-            helpers.data_datetime("ns"), id="datetime_ns",
+            helpers.data_datetime("ns"),
+            id="datetime_ns",
         ),
         # Not writtable to parquet
         pytest.param(

--- a/python/datafusion/tests/test_sql.py
+++ b/python/datafusion/tests/test_sql.py
@@ -382,19 +382,18 @@ _null_mask = np.array([False, True, False])
         pytest.param(
             pa.array([b"1111", b"2222", b"3333"], pa.binary(4), _null_mask),
             id="binary4",
-            marks=pytest.mark.xfail,
         ),
         pytest.param(
             helpers.data_datetime("s"), id="datetime_s", marks=pytest.mark.xfail
         ),
         pytest.param(
-            helpers.data_datetime("ms"), id="datetime_ms", marks=pytest.mark.xfail
+            helpers.data_datetime("ms"), id="datetime_ms",
         ),
         pytest.param(
-            helpers.data_datetime("us"), id="datetime_us", marks=pytest.mark.xfail
+            helpers.data_datetime("us"), id="datetime_us",
         ),
         pytest.param(
-            helpers.data_datetime("ns"), id="datetime_ns", marks=pytest.mark.xfail
+            helpers.data_datetime("ns"), id="datetime_ns",
         ),
         # Not writtable to parquet
         pytest.param(

--- a/python/datafusion/tests/test_sql.py
+++ b/python/datafusion/tests/test_sql.py
@@ -382,10 +382,13 @@ _null_mask = np.array([False, True, False])
             pa.array([b"1111", b"2222", b"3333"], pa.binary(4), _null_mask),
             id="binary4",
         ),
+        # `timestamp[s]` does not roundtrip for pyarrow.parquet: https://github.com/apache/arrow/issues/41382
         pytest.param(
             helpers.data_datetime("s"),
             id="datetime_s",
-            marks=pytest.mark.xfail(reason="Mismatch in format"),
+            marks=pytest.mark.xfail(
+                reason="pyarrow.parquet does not support timestamp[s] roundtrips"
+            ),
         ),
         pytest.param(
             helpers.data_datetime("ms"),


### PR DESCRIPTION
 # Rationale for this change
These tests are now passing, so I've removed the `xfail` from them.

`pyarrow.parquet` does not preserve `timestamp[s]` data type roundtrip between write and read.

https://github.com/apache/arrow/issues/41382

# Are there any user-facing changes?
No.