### PR TITLE
chore(ci): remove Mambaforge variant from CI

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -75,7 +75,7 @@ jobs:
           channel-priority: strict
       - name: Install dependencies
         run: |
-          conda install -c conda-forge conda-verify
+          conda install -c conda-forge conda-build conda-verify
 
           which python
           pip list

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -70,17 +70,16 @@ jobs:
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-variant: Mambaforge
-          use-mamba: true
+          miniforge-variant: Miniforge3
           python-version: "3.8"
           channel-priority: strict
       - name: Install dependencies
         run: |
-          mamba install -c conda-forge boa conda-verify
+          conda install -c conda-forge conda-verify
 
           which python
           pip list
-          mamba list
+          conda list
       # Clean the conda cache
       - name: Clean Conda Cache
         run: conda clean --all --yes
@@ -89,7 +88,7 @@ jobs:
           # suffix for nightly package versions
           export VERSION_SUFFIX=a`date +%y%m%d`
 
-          conda mambabuild conda/recipes \
+          conda build conda/recipes \
                            --python ${{ matrix.python }} \
                            --variants "{target_platform: [${{ matrix.arch }}]}" \
                            --error-overlinking \
@@ -99,7 +98,7 @@ jobs:
       - name: Test conda packages
         if: matrix.arch == 'linux-64'  # can only test native platform packages
         run: |
-          conda mambabuild --test packages/${{ matrix.arch }}/*.tar.bz2
+          conda build --test packages/${{ matrix.arch }}/*.tar.bz2
       - name: Upload conda packages as artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
# Which issue does this PR close?

Closes #893.

 # Rationale for this change
It is being sunsetted and will stop working entirely in Jan 2025.

Ref: https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/

# What changes are included in this PR?
Removes the `mambaforge` variant for our `conda` CI.

# Are there any user-facing changes?
No.