### PR TITLE
Use OnceLock to store TokioRuntime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ description = "Apache DataFusion DataFrame and SQL Query Engine"
 readme = "README.md"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.78"
 include = ["/src", "/datafusion", "/LICENSE.txt", "pyproject.toml", "Cargo.toml", "Cargo.lock"]
 
 [features]

--- a/python/datafusion/__init__.py
+++ b/python/datafusion/__init__.py
@@ -36,7 +36,7 @@ from .context import (
 from .catalog import Catalog, Database, Table
 
 # The following imports are okay to remain as opaque to the user.
-from ._internal import Config, runtime
+from ._internal import Config
 
 from .record_batch import RecordBatchStream, RecordBatch
 
@@ -75,7 +75,6 @@ __all__ = [
     "literal",
     "lit",
     "DFSchema",
-    "runtime",
     "Catalog",
     "Database",
     "Table",

--- a/src/context.rs
+++ b/src/context.rs
@@ -982,7 +982,7 @@ impl PySessionContext {
     ) -> PyResult<PyRecordBatchStream> {
         let ctx: TaskContext = TaskContext::from(&self.ctx.state());
         // create a Tokio runtime to run the async code
-        let rt = &get_tokio_runtime(py).0;
+        let rt = &get_tokio_runtime().0;
         let plan = plan.plan.clone();
         let fut: JoinHandle<datafusion::common::Result<SendableRecordBatchStream>> =
             rt.spawn(async move { plan.execute(part, Arc::new(ctx)) });

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -543,7 +543,7 @@ impl PyDataFrame {
 
     fn execute_stream(&self, py: Python) -> PyResult<PyRecordBatchStream> {
         // create a Tokio runtime to run the async code
-        let rt = &get_tokio_runtime(py).0;
+        let rt = &get_tokio_runtime().0;
         let df = self.df.as_ref().clone();
         let fut: JoinHandle<datafusion::common::Result<SendableRecordBatchStream>> =
             rt.spawn(async move { df.execute_stream().await });
@@ -553,7 +553,7 @@ impl PyDataFrame {
 
     fn execute_stream_partitioned(&self, py: Python) -> PyResult<Vec<PyRecordBatchStream>> {
         // create a Tokio runtime to run the async code
-        let rt = &get_tokio_runtime(py).0;
+        let rt = &get_tokio_runtime().0;
         let df = self.df.as_ref().clone();
         let fut: JoinHandle<datafusion::common::Result<Vec<SendableRecordBatchStream>>> =
             rt.spawn(async move { df.execute_stream_partitioned().await });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@ pub mod utils;
 static GLOBAL: MiMalloc = MiMalloc;
 
 // Used to define Tokio Runtime as a Python module attribute
-#[pyclass]
 pub(crate) struct TokioRuntime(tokio::runtime::Runtime);
 
 /// Low-level DataFusion internal package.
@@ -75,11 +74,6 @@ pub(crate) struct TokioRuntime(tokio::runtime::Runtime);
 /// datafusion directory.
 #[pymodule]
 fn _internal(py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
-    // Register the Tokio Runtime as a module attribute so we can reuse it
-    m.add(
-        "runtime",
-        TokioRuntime(tokio::runtime::Runtime::new().unwrap()),
-    )?;
     // Register the python classes
     m.add_class::<catalog::PyCatalog>()?;
     m.add_class::<catalog::PyDatabase>()?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,9 +32,7 @@ pub(crate) fn get_tokio_runtime() -> &'static TokioRuntime {
     // which adds a check in that disallows calls from a forked process
     // https://github.com/delta-io/delta-rs/blob/87010461cfe01563d91a4b9cd6fa468e2ad5f283/python/src/utils.rs#L10-L31
     static RUNTIME: OnceLock<TokioRuntime> = OnceLock::new();
-    RUNTIME.get_or_init(|| {
-        TokioRuntime(tokio::runtime::Runtime::new().unwrap())
-    })
+    RUNTIME.get_or_init(|| TokioRuntime(tokio::runtime::Runtime::new().unwrap()))
 }
 
 /// Utility to collect rust futures with GIL released

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,8 +33,7 @@ pub(crate) fn get_tokio_runtime() -> &'static TokioRuntime {
     // https://github.com/delta-io/delta-rs/blob/87010461cfe01563d91a4b9cd6fa468e2ad5f283/python/src/utils.rs#L10-L31
     static RUNTIME: OnceLock<TokioRuntime> = OnceLock::new();
     RUNTIME.get_or_init(|| {
-        let rt = TokioRuntime(tokio::runtime::Runtime::new().unwrap());
-        rt
+        TokioRuntime(tokio::runtime::Runtime::new().unwrap())
     })
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,18 +20,16 @@ use crate::TokioRuntime;
 use datafusion::logical_expr::Volatility;
 use pyo3::prelude::*;
 use std::future::Future;
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 use tokio::runtime::Runtime;
 
 /// Utility to get the Tokio Runtime from Python
-pub(crate) fn get_tokio_runtime() -> Arc<TokioRuntime> {
-    static RUNTIME: OnceLock<Arc<TokioRuntime>> = OnceLock::new();
-    RUNTIME
-        .get_or_init(|| {
-            let rt = TokioRuntime(tokio::runtime::Runtime::new().unwrap());
-            Arc::new(rt)
-        })
-        .clone()
+pub(crate) fn get_tokio_runtime() -> &'static TokioRuntime {
+    static RUNTIME: OnceLock<TokioRuntime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        let rt = TokioRuntime(tokio::runtime::Runtime::new().unwrap());
+        rt
+    })
 }
 
 /// Utility to collect rust futures with GIL released

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, OnceLock};
 use tokio::runtime::Runtime;
 
 /// Utility to get the Tokio Runtime from Python
-pub(crate) fn get_tokio_runtime(_: Python) -> Arc<TokioRuntime> {
+pub(crate) fn get_tokio_runtime() -> Arc<TokioRuntime> {
     static RUNTIME: OnceLock<Arc<TokioRuntime>> = OnceLock::new();
     RUNTIME
         .get_or_init(|| {
@@ -40,7 +40,7 @@ where
     F: Future + Send,
     F::Output: Send,
 {
-    let runtime: &Runtime = &get_tokio_runtime(py).0;
+    let runtime: &Runtime = &get_tokio_runtime().0;
     py.allow_threads(|| runtime.block_on(f))
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,7 +24,13 @@ use std::sync::OnceLock;
 use tokio::runtime::Runtime;
 
 /// Utility to get the Tokio Runtime from Python
+#[inline]
 pub(crate) fn get_tokio_runtime() -> &'static TokioRuntime {
+    // NOTE: Other pyo3 python libraries have had issues with using tokio
+    // behind a forking app-server like `gunicorn`
+    // If we run into that problem, in the future we can look to `delta-rs`
+    // which adds a check in that disallows calls from a forked process
+    // https://github.com/delta-io/delta-rs/blob/87010461cfe01563d91a4b9cd6fa468e2ad5f283/python/src/utils.rs#L10-L31
     static RUNTIME: OnceLock<TokioRuntime> = OnceLock::new();
     RUNTIME.get_or_init(|| {
         let rt = TokioRuntime(tokio::runtime::Runtime::new().unwrap());


### PR DESCRIPTION
# Which issue does this PR close?

Closes #737.

 # Rationale for this change

To avoid repeatedly recreating the tokio runtime, https://github.com/apache/datafusion-python/pull/341 began storing the tokio runtime on the python heap at `datafusion.runtime`. 

This created the requirement that the `datafusion` python package must be available to any user of the rust crate `datafusion-python`.

However, some users (#737) want to leverage the rust-crate `datafusion-python` to create their own custom python package without depending on or using the python `datafusion` package.

# What changes are included in this PR?
This PR uses `std::sync::OnceLock` instead of the python heap to ensure that only one tokio runtime gets created once.

This both removes the implicit dependency and avoids `rust --> python --> rust` roundtrip every time the runtime is used.

# Are there any user-facing changes?
`datafusion.runtime` has been removed, but that was already unusable for users of the python package.