### PR TITLE
fix example of reading parquet from s3

### DIFF
--- a/examples/sql-parquet-s3.py
+++ b/examples/sql-parquet-s3.py
@@ -31,7 +31,7 @@ s3 = AmazonS3(
 
 ctx = datafusion.SessionContext()
 path = f"s3://{bucket_name}/"
-ctx.register_object_store(path, s3)
+ctx.register_object_store("s3://", s3, None)
 
 ctx.register_parquet("trips", path)
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Example of reading parquet from S3 doesn't work because wrong number of arguments passed to `register_object_store()` function.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR fixes `register_object_store()` call.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->