### PR TITLE
refactor: rename to `with_column_renamed` to `rename`

### DIFF
--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -160,6 +160,9 @@ class DataFrame:
         """
         return DataFrame(self.df.with_column(name, expr.expr))
 
+    @deprecated(
+        "with_column_renamed() is deprecated. Use :py:meth:`~DataFrame.rename` instead"
+    )
     def with_column_renamed(self, old_name: str, new_name: str) -> DataFrame:
         r"""Rename one column by applying a new projection.
 
@@ -175,7 +178,23 @@ class DataFrame:
         Returns:
             DataFrame with the column renamed.
         """
-        return DataFrame(self.df.with_column_renamed(old_name, new_name))
+        return DataFrame(self.df.rename({old_name: new_name}))
+
+    def rename(self, mapping: dict[str, str]) -> DataFrame:
+        r"""Rename one or multiple columns by applying a new projection.
+
+        This is a no-op if the column to be renamed does not exist.
+
+        The method supports case sensitive rename with wrapping column name
+        into one the following symbols (" or ' or \`).
+
+        Args:
+            mapping (dict[str, str]): mapping of old (key) to new (value) names
+
+        Returns:
+            DataFrame with one or multiple columns renamed.
+        """
+        return DataFrame(self.df.rename(mapping))
 
     def aggregate(
         self, group_by: list[Expr] | Expr, aggs: list[Expr] | Expr

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -160,9 +160,6 @@ class DataFrame:
         """
         return DataFrame(self.df.with_column(name, expr.expr))
 
-    @deprecated(
-        "with_column_renamed() is deprecated. Use :py:meth:`~DataFrame.rename` instead"
-    )
     def with_column_renamed(self, old_name: str, new_name: str) -> DataFrame:
         r"""Rename one column by applying a new projection.
 
@@ -189,7 +186,7 @@ class DataFrame:
         into one the following symbols (" or ' or \`).
 
         Args:
-            mapping (dict[str, str]): mapping of old (key) to new (value) names
+            mapping: mapping of old (key) to new (value) names
 
         Returns:
             DataFrame with one or multiple columns renamed.

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -206,7 +206,7 @@ def test_with_column(df):
 
 
 def test_rename(df):
-    df = df.with_column("c", column("a") + column("b")).rename({"c":"sum"})
+    df = df.with_column("c", column("a") + column("b")).rename({"c": "sum"})
 
     result = df.collect()[0]
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -205,8 +205,8 @@ def test_with_column(df):
     assert result.column(2) == pa.array([5, 7, 9])
 
 
-def test_with_column_renamed(df):
-    df = df.with_column("c", column("a") + column("b")).with_column_renamed("c", "sum")
+def test_rename(df):
+    df = df.with_column("c", column("a") + column("b")).rename({"c":"sum"})
 
     result = df.collect()[0]
 

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
 use std::ffi::CString;
 use std::sync::Arc;
 
@@ -180,14 +181,13 @@ impl PyDataFrame {
         Ok(Self::new(df))
     }
 
-    /// Rename one column by applying a new projection. This is a no-op if the column to be
+    /// Rename single or multiple columns by applying a new projection. This is a no-op if the column to be
     /// renamed does not exist.
-    fn with_column_renamed(&self, old_name: &str, new_name: &str) -> PyResult<Self> {
-        let df = self
-            .df
-            .as_ref()
-            .clone()
-            .with_column_renamed(old_name, new_name)?;
+    fn rename(&self, mapping: HashMap<String, String>) -> PyResult<Self> {
+        let mut df = self.df.as_ref().clone();
+        for (old_name, new_name) in mapping.iter() {
+            df = df.with_column_renamed(old_name, new_name)?
+        }
         Ok(Self::new(df))
     }
 


### PR DESCRIPTION
# Which issue does this PR close?
- related https://github.com/apache/datafusion-python/issues/875

 # Rationale for this change
Simpler API that allows multiple renames instead of having to chain .with_column_renamed. 

# What changes are included in this PR?
- adds a rename method which in Rust calls `with_column_renamed`. I can look into adding a native rename in datafusion rust eventually.
- deprecates `with_column_renamed`

# Are there any user-facing changes?
- deprecates `with_column_renamed`