### PR TITLE
feat: add `with_columns`

### DIFF
--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -21,7 +21,7 @@ See :ref:`user_guide_concepts` in the online documentation for more information.
 
 from __future__ import annotations
 
-from typing import Any, Iterable, List, TYPE_CHECKING
+from typing import Any, Iterable, List, Literal, TYPE_CHECKING
 from datafusion.record_batch import RecordBatchStream
 from typing_extensions import deprecated
 from datafusion.plan import LogicalPlan, ExecutionPlan

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -168,9 +168,7 @@ class DataFrame:
         By passing expressions, iteratables of expressions, or named expressions. To
         pass named expressions use the form name=Expr.
 
-        Example usage:
-
-            The following will add 4 columns labeled a, b, c, and d.
+        Example usage: The following will add 4 columns labeled a, b, c, and d::
 
             df = df.with_columns(
                 lit(0).alias('a'),
@@ -179,11 +177,11 @@ class DataFrame:
                 )
 
         Args:
-            *exprs: Name of the column to add.
-            **named_exprs: Expression to compute the column.
+            exprs: Either a single expression or an iterable of expressions to add.
+            named_exprs: Named expressions in the form of ``name=expr``
 
         Returns:
-            DataFrame with the new column.
+            DataFrame with the new columns added.
         """
 
         def _simplify_expression(

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -163,7 +163,20 @@ class DataFrame:
     def with_columns(
         self, *exprs: Expr | Iterable[Expr], **named_exprs: Expr
     ) -> DataFrame:
-        """Add an additional column to the DataFrame.
+        """Add columns to the DataFrame.
+
+        By passing expressions, iteratables of expressions, or named expressions. To
+        pass named expressions use the form name=Expr.
+
+        Example usage:
+
+            The following will add 4 columns labeled a, b, c, and d.
+
+            df = df.with_columns(
+                lit(0).alias('a'),
+                [lit(1).alias('b'), lit(2).alias('c')],
+                d=lit(3)
+                )
 
         Args:
             *exprs: Name of the column to add.

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -205,6 +205,37 @@ def test_with_column(df):
     assert result.column(2) == pa.array([5, 7, 9])
 
 
+def test_with_columns(df):
+    df = df.with_columns(
+        (column("a") + column("b")).alias("c"),
+        (column("a") + column("b")).alias("d"),
+        [
+            (column("a") + column("b")).alias("e"),
+            (column("a") + column("b")).alias("f"),
+        ],
+        g=(column("a") + column("b")),
+    )
+
+    # execute and collect the first (and only) batch
+    result = df.collect()[0]
+
+    assert result.schema.field(0).name == "a"
+    assert result.schema.field(1).name == "b"
+    assert result.schema.field(2).name == "c"
+    assert result.schema.field(3).name == "d"
+    assert result.schema.field(4).name == "e"
+    assert result.schema.field(5).name == "f"
+    assert result.schema.field(6).name == "g"
+
+    assert result.column(0) == pa.array([1, 2, 3])
+    assert result.column(1) == pa.array([4, 5, 6])
+    assert result.column(2) == pa.array([5, 7, 9])
+    assert result.column(3) == pa.array([5, 7, 9])
+    assert result.column(4) == pa.array([5, 7, 9])
+    assert result.column(5) == pa.array([5, 7, 9])
+    assert result.column(6) == pa.array([5, 7, 9])
+
+
 def test_with_column_renamed(df):
     df = df.with_column("c", column("a") + column("b")).with_column_renamed("c", "sum")
 

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -180,6 +180,16 @@ impl PyDataFrame {
         Ok(Self::new(df))
     }
 
+    fn with_columns(&self, exprs: Vec<PyExpr>) -> PyResult<Self> {
+        let mut df = self.df.as_ref().clone();
+        for expr in exprs {
+            let expr: Expr = expr.into();
+            let name = format!("{}", expr.schema_name());
+            df = df.with_column(name.as_str(), expr)?
+        }
+        Ok(Self::new(df))
+    }
+
     /// Rename one column by applying a new projection. This is a no-op if the column to be
     /// renamed does not exist.
     fn with_column_renamed(&self, old_name: &str, new_name: &str) -> PyResult<Self> {


### PR DESCRIPTION
# Which issue does this PR close?
-  closes https://github.com/apache/datafusion-python/issues/838
- related https://github.com/apache/datafusion-python/issues/875

 # Rationale for this change
Gives more flexibility to the user.

# What changes are included in this PR?
Adds a `with_columns` which is a wrapper around with_column in Rust, the schema_name of the expr is used as the name. However I think we could improve over this in a follow up, since we should keep the original  name unless somewhere down the expr path alias was called.

See this example of Polars VS Datafusion now:

original df
```python
+---+---+---+
| a | b | c |
+---+---+---+
| 1 | 4 | 8 |
| 2 | 5 | 5 |
| 3 | 6 | 8 |
+---+---+---+
```

Polars
```python
df.with_columns(pl.col('a)+5)
┌─────┬─────┬─────┐
│ a   ┆ b   ┆ c   │
│ --- ┆ --- ┆ --- │
│ i64 ┆ i64 ┆ i64 │
╞═════╪═════╪═════╡
│ 6   ┆ 4   ┆ 8   │
│ 7   ┆ 5   ┆ 5   │
│ 8   ┆ 6   ┆ 8   │
└─────┴─────┴─────┘
```

Datafusion
```python
df.with_columns(column('a')+5)
+---+---+---+--------------+
| a | b | c | a + Int64(5) |
+---+---+---+--------------+
| 1 | 4 | 8 | 6            |
| 2 | 5 | 5 | 7            |
| 3 | 6 | 8 | 8            |
+---+---+---+--------------+
```

# Are there any user-facing changes?
Adds new `with_columns` method on DataFrame.

