### PR TITLE
feat: add `head`, `tail` methods

### DIFF
--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -223,7 +223,7 @@ class DataFrame:
         """
         return DataFrame(self.df.limit(count, offset))
 
-    def head(self, n: int) -> DataFrame:
+    def head(self, n: int = 5) -> DataFrame:
         """Return a new :py:class:`DataFrame` with a limited number of rows.
 
         Args:
@@ -234,10 +234,11 @@ class DataFrame:
         """
         return DataFrame(self.df.limit(n, 0))
 
-    def tail(self, n: int) -> DataFrame:
+    def tail(self, n: int = 5) -> DataFrame:
         """Return a new :py:class:`DataFrame` with a limited number of rows.
 
-        Be aware this could be potentially expensive due to the size of the frame.
+        Be aware this could be potentially expensive since the row size needs to be
+        determined of the dataframe. This is done by collecting it.
 
         Args:
             n: Number of rows to take from the tail of the DataFrame.

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -223,6 +223,30 @@ class DataFrame:
         """
         return DataFrame(self.df.limit(count, offset))
 
+    def head(self, n: int) -> DataFrame:
+        """Return a new :py:class:`DataFrame` with a limited number of rows.
+
+        Args:
+            n: Number of rows to take from the head of the DataFrame.
+
+        Returns:
+            DataFrame after limiting.
+        """
+        return DataFrame(self.df.limit(n, 0))
+
+    def tail(self, n: int) -> DataFrame:
+        """Return a new :py:class:`DataFrame` with a limited number of rows.
+
+        Be aware this could be potentially expensive due to the size of the frame.
+
+        Args:
+            n: Number of rows to take from the tail of the DataFrame.
+
+        Returns:
+            DataFrame after limiting.
+        """
+        return DataFrame(self.df.limit(n, max(0, self.count() - n)))
+
     def collect(self) -> list[pa.RecordBatch]:
         """Execute this :py:class:`DataFrame` and collect results into memory.
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -190,6 +190,28 @@ def test_limit_with_offset(df):
     assert len(result.column(1)) == 1
 
 
+def test_head(df):
+    df = df.head(1)
+
+    # execute and collect the first (and only) batch
+    result = df.collect()[0]
+
+    assert result.column(0) == pa.array([1])
+    assert result.column(1) == pa.array([4])
+    assert result.column(2) == pa.array([8])
+
+
+def test_tail(df):
+    df = df.tail(1)
+
+    # execute and collect the first (and only) batch
+    result = df.collect()[0]
+
+    assert result.column(0) == pa.array([3])
+    assert result.column(1) == pa.array([6])
+    assert result.column(2) == pa.array([8])
+
+
 def test_with_column(df):
     df = df.with_column("c", column("a") + column("b"))
 


### PR DESCRIPTION
# Which issue does this PR close?
- related https://github.com/apache/datafusion-python/issues/875

 # Rationale for this change
Common methods similar to pyspark/polars/pandas api

# What changes are included in this PR?
-  Adds a head method, which  uses limit underneath.  Same as tail but calls the count of the dataframe to know where to start returning it from