### PR TITLE
feat: add `cast` to DataFrame

### DIFF
--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -245,6 +245,19 @@ class DataFrame:
         exprs_raw = [sort_or_default(expr) for expr in exprs]
         return DataFrame(self.df.sort(*exprs_raw))
 
+    def cast(self, mapping: dict[str, pa.DataType[Any]]) -> DataFrame:
+        """Cast all or a subset of columns to new dtype.
+
+        Args:
+            mapping (dict[str, pa.DataType[Any]]):  Mapped with column as key and column
+                dtype as value.
+
+        Returns:
+            DataFrame after casting columns
+        """
+        exprs = [Expr.column(col).cast(dtype) for col, dtype in mapping.items()]
+        return self.with_columns(exprs)
+
     def limit(self, count: int, offset: int = 0) -> DataFrame:
         """Return a new :py:class:`DataFrame` with a limited number of rows.
 

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -246,11 +246,10 @@ class DataFrame:
         return DataFrame(self.df.sort(*exprs_raw))
 
     def cast(self, mapping: dict[str, pa.DataType[Any]]) -> DataFrame:
-        """Cast all or a subset of columns to new dtype.
+        """Cast one or more columns to a different data type.
 
         Args:
-            mapping (dict[str, pa.DataType[Any]]):  Mapped with column as key and column
-                dtype as value.
+            mapping: Mapped with column as key and column dtype as value.
 
         Returns:
             DataFrame after casting columns

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -236,6 +236,15 @@ def test_with_columns(df):
     assert result.column(6) == pa.array([5, 7, 9])
 
 
+def test_cast(df):
+    df = df.cast({"a": pa.float16(), "b": pa.list_(pa.uint32())})
+    expected = pa.schema(
+        [("a", pa.float16()), ("b", pa.list_(pa.uint32())), ("c", pa.int64())]
+    )
+
+    assert df.schema() == expected
+
+
 def test_with_column_renamed(df):
     df = df.with_column("c", column("a") + column("b")).with_column_renamed("c", "sum")
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -205,6 +205,37 @@ def test_with_column(df):
     assert result.column(2) == pa.array([5, 7, 9])
 
 
+def test_with_columns(df):
+    df = df.with_columns(
+        (column("a") + column("b")).alias("c"),
+        (column("a") + column("b")).alias("d"),
+        [
+            (column("a") + column("b")).alias("e"),
+            (column("a") + column("b")).alias("f"),
+        ],
+        g=(column("a") + column("b")),
+    )
+
+    # execute and collect the first (and only) batch
+    result = df.collect()[0]
+
+    assert result.schema.field(0).name == "a"
+    assert result.schema.field(1).name == "b"
+    assert result.schema.field(2).name == "c"
+    assert result.schema.field(3).name == "d"
+    assert result.schema.field(4).name == "e"
+    assert result.schema.field(5).name == "f"
+    assert result.schema.field(6).name == "g"
+
+    assert result.column(0) == pa.array([1, 2, 3])
+    assert result.column(1) == pa.array([4, 5, 6])
+    assert result.column(2) == pa.array([5, 7, 9])
+    assert result.column(3) == pa.array([5, 7, 9])
+    assert result.column(4) == pa.array([5, 7, 9])
+    assert result.column(5) == pa.array([5, 7, 9])
+    assert result.column(6) == pa.array([5, 7, 9])
+
+
 def test_with_column_renamed(df):
     df = df.with_column("c", column("a") + column("b")).with_column_renamed("c", "sum")
 

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -180,6 +180,16 @@ impl PyDataFrame {
         Ok(Self::new(df))
     }
 
+    fn with_columns(&self, exprs: Vec<PyExpr>) -> PyResult<Self> {
+        let mut df = self.df.as_ref().clone();
+        for expr in exprs {
+            let expr: Expr = expr.into();
+            let name = format!("{}", expr.schema_name());
+            df = df.with_column(name.as_str(), expr)?
+        }
+        Ok(Self::new(df))
+    }
+
     /// Rename one column by applying a new projection. This is a no-op if the column to be
     /// renamed does not exist.
     fn with_column_renamed(&self, old_name: &str, new_name: &str) -> PyResult<Self> {


### PR DESCRIPTION
# Which issue does this PR close?
- related https://github.com/apache/datafusion-python/issues/875

 # Rationale for this change
A top level cast is very practical and a common practice to do, since it's just a projection of columns, we call with_columns underneath. Therefore it builds on top of: https://github.com/apache/datafusion-python/pull/909,  so that one needs to be merged first.

# What changes are included in this PR?
- adds a `cast` method which takes in a mapping of col_names and dtypes. 

Important: I am going to work soon on creating a datafusion-python native schema struct and classes. Because going to pyarrow is simply to painful :) and then we can also drop the pyarrow dependency for that part

# Are there any user-facing changes?
- adds new method.