### PR TITLE
Add array_empty scalar function

### DIFF
--- a/docs/source/user-guide/common-operations/expressions.rst
+++ b/docs/source/user-guide/common-operations/expressions.rst
@@ -77,11 +77,24 @@ approaches.
     df = ctx.from_pydict({"a": [[1, 2, 3], [4, 5, 6]]})
     df.select(col("a")[0].alias("a0"))
 
-
 .. warning::
 
     Indexing an element of an array via ``[]`` starts at index 0 whereas
     :py:func:`~datafusion.functions.array_element` starts at index 1.
+
+To check if an array is empty, you can use the function :py:func:`datafusion.functions.array_empty`.
+This function returns a boolean indicating whether the array is empty.
+
+.. ipython:: python
+
+    from datafusion import SessionContext, col
+    from datafusion.functions import array_empty
+
+    ctx = SessionContext()
+    df = ctx.from_pydict({"a": [[], [1, 2, 3]]})
+    df.select(array_empty(col("a")).alias("is_empty"))
+
+In this example, the `is_empty` column will contain `True` for the first row and `False` for the second row.
 
 Structs
 -------

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -51,6 +51,7 @@ __all__ = [
     "array_dims",
     "array_distinct",
     "array_element",
+    "array_empty",
     "array_except",
     "array_extract",
     "array_has",
@@ -1158,6 +1159,11 @@ def list_dims(array: Expr) -> Expr:
 def array_element(array: Expr, n: Expr) -> Expr:
     """Extracts the element with the index n from the array."""
     return Expr(f.array_element(array.expr, n.expr))
+
+
+def array_empty(array: Expr) -> Expr:
+    """Returns a boolean indicating whether the array is empty."""
+    return Expr(f.array_empty(array.expr))
 
 
 def array_extract(array: Expr, n: Expr) -> Expr:

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -310,6 +310,10 @@ def py_flatten(arr):
             lambda data: [r[0] for r in data],
         ],
         [
+            lambda col: f.array_empty(col),
+            lambda data: [len(r) == 0 for r in data],
+        ],
+        [
             lambda col: f.array_extract(col, literal(1)),
             lambda data: [r[0] for r in data],
         ],

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -572,6 +572,7 @@ array_fn!(array_to_string, array delimiter);
 array_fn!(array_dims, array);
 array_fn!(array_distinct, array);
 array_fn!(array_element, array element);
+array_fn!(array_empty, array);
 array_fn!(array_length, array);
 array_fn!(array_has, first_array second_array);
 array_fn!(array_has_all, first_array second_array);
@@ -1003,6 +1004,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(array_dims))?;
     m.add_wrapped(wrap_pyfunction!(array_distinct))?;
     m.add_wrapped(wrap_pyfunction!(array_element))?;
+    m.add_wrapped(wrap_pyfunction!(array_empty))?;
     m.add_wrapped(wrap_pyfunction!(array_length))?;
     m.add_wrapped(wrap_pyfunction!(array_has))?;
     m.add_wrapped(wrap_pyfunction!(array_has_all))?;


### PR DESCRIPTION
# Which issue does this PR close?

Completes a task in #463

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This PR introduces a new function, array_empty, to check if an array is empty, returning a boolean.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Added the array_empty function. 
Updated the Python bindings in functions.py and provided unit tests for array_empty in test_functions.py.
Updated the documentation (expressions.rst) to include examples on how to use the new array_empty function.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
The array_empty function is now available for users working with arrays. It is exposed both in Rust and Python, allowing users to check whether arrays are empty within their DataFusion queries.

There are no breaking changes to public APIs.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->