### PR TITLE
add `cardinality` function to calculate total distinct elements in an array

### DIFF
--- a/docs/source/user-guide/common-operations/expressions.rst
+++ b/docs/source/user-guide/common-operations/expressions.rst
@@ -96,6 +96,20 @@ This function returns a boolean indicating whether the array is empty.
 
 In this example, the `is_empty` column will contain `True` for the first row and `False` for the second row.
 
+To get the total number of elements in an array, you can use the function :py:func:`datafusion.functions.cardinality`.
+This function returns an integer indicating the total number of elements in the array.
+
+.. ipython:: python
+
+    from datafusion import SessionContext, col
+    from datafusion.functions import cardinality
+
+    ctx = SessionContext()
+    df = ctx.from_pydict({"a": [[1, 2, 3], [4, 5, 6]]})
+    df.select(cardinality(col("a")).alias("num_elements"))
+
+In this example, the `num_elements` column will contain `3` for both rows.
+
 Structs
 -------
 

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -132,6 +132,7 @@ __all__ = [
     "find_in_set",
     "first_value",
     "flatten",
+    "cardinality",
     "floor",
     "from_unixtime",
     "gcd",
@@ -1514,6 +1515,11 @@ def list_resize(array: Expr, size: Expr, value: Expr) -> Expr:
 def flatten(array: Expr) -> Expr:
     """Flattens an array of arrays into a single array."""
     return Expr(f.flatten(array.expr))
+
+
+def cardinality(array: Expr) -> Expr:
+    """Returns the total number of elements in the array."""
+    return Expr(f.cardinality(array.expr))
 
 
 # aggregate functions

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -540,6 +540,24 @@ def test_array_function_flatten():
         )
 
 
+def test_array_function_cardinality():
+    data = [[1, 2, 3], [4, 4, 5, 6]]
+    ctx = SessionContext()
+    batch = pa.RecordBatch.from_arrays([np.array(data, dtype=object)], names=["arr"])
+    df = ctx.create_dataframe([[batch]])
+
+    stmt = f.cardinality(column("arr"))
+    py_expr = [len(arr) for arr in data]  # Expected lengths: [3, 3]
+    # assert py_expr lengths
+
+    query_result = df.select(stmt).collect()[0].column(0)
+
+    for a, b in zip(query_result, py_expr):
+        np.testing.assert_array_equal(
+            np.array([a.as_py()], dtype=int), np.array([b], dtype=int)
+        )
+
+
 @pytest.mark.parametrize(
     ("stmt", "py_expr"),
     [

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -594,6 +594,7 @@ array_fn!(array_intersect, first_array second_array);
 array_fn!(array_union, array1 array2);
 array_fn!(array_except, first_array second_array);
 array_fn!(array_resize, array size value);
+array_fn!(cardinality, array);
 array_fn!(flatten, array);
 array_fn!(range, start stop step);
 
@@ -1030,6 +1031,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(array_sort))?;
     m.add_wrapped(wrap_pyfunction!(array_slice))?;
     m.add_wrapped(wrap_pyfunction!(flatten))?;
+    m.add_wrapped(wrap_pyfunction!(cardinality))?;
 
     // Window Functions
     m.add_wrapped(wrap_pyfunction!(lead))?;


### PR DESCRIPTION
# Which issue does this PR close?

Completes a task in #463

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This PR introduces a new function, cardinality, which returns the number of distinct elements in a array

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Added the cardinality function. 
Updated the Python bindings in functions.py and provided unit tests for cardinality in test_functions.py.
Updated the documentation (expressions.rst) to include examples on how to use the new cardinality function.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
The cardinality function is now available for users working with arrays. It is exposed both in Rust and Python, allowing users to obtain the number of distinct elements in their DataFusion queries.

There are no breaking changes to public APIs.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->