### PR TITLE
Add empty scalar function (alias of array_empty), fix a small typo

### DIFF
--- a/docs/source/user-guide/common-operations/expressions.rst
+++ b/docs/source/user-guide/common-operations/expressions.rst
@@ -82,7 +82,7 @@ approaches.
     Indexing an element of an array via ``[]`` starts at index 0 whereas
     :py:func:`~datafusion.functions.array_element` starts at index 1.
 
-To check if an array is empty, you can use the function :py:func:`datafusion.functions.array_empty`.
+To check if an array is empty, you can use the function :py:func:`datafusion.functions.array_empty` or `datafusion.functions.empty`.
 This function returns a boolean indicating whether the array is empty.
 
 .. ipython:: python

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -1524,9 +1524,7 @@ def cardinality(array: Expr) -> Expr:
 
 
 def empty(array: Expr) -> Expr:
-    """
-    This is an alias for :py:func:`array_empty`.
-    """
+    """This is an alias for :py:func:`array_empty`."""
     return array_empty(array)
 
 
@@ -2148,7 +2146,7 @@ def first_value(
         expression: Argument to perform bitwise calculation on
         filter: If provided, only compute against rows for which the filter is True
         order_by: Set the ordering of the expression to evaluate
-        null_treatment: Assign whether to respect or ignull null values.
+        null_treatment: Assign whether to respect or ignore null values.
     """
     order_by_raw = sort_list_to_raw_sort_list(order_by)
     filter_raw = filter.expr if filter is not None else None
@@ -2180,7 +2178,7 @@ def last_value(
         expression: Argument to perform bitwise calculation on
         filter: If provided, only compute against rows for which the filter is True
         order_by: Set the ordering of the expression to evaluate
-        null_treatment: Assign whether to respect or ignull null values.
+        null_treatment: Assign whether to respect or ignore null values.
     """
     order_by_raw = sort_list_to_raw_sort_list(order_by)
     filter_raw = filter.expr if filter is not None else None
@@ -2214,7 +2212,7 @@ def nth_value(
         n: Index of value to return. Starts at 1.
         filter: If provided, only compute against rows for which the filter is True
         order_by: Set the ordering of the expression to evaluate
-        null_treatment: Assign whether to respect or ignull null values.
+        null_treatment: Assign whether to respect or ignore null values.
     """
     order_by_raw = sort_list_to_raw_sort_list(order_by)
     filter_raw = filter.expr if filter is not None else None

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -125,6 +125,7 @@ __all__ = [
     "decode",
     "degrees",
     "digest",
+    "empty",
     "encode",
     "ends_with",
     "exp",
@@ -1520,6 +1521,13 @@ def flatten(array: Expr) -> Expr:
 def cardinality(array: Expr) -> Expr:
     """Returns the total number of elements in the array."""
     return Expr(f.cardinality(array.expr))
+
+
+def empty(array: Expr) -> Expr:
+    """
+    This is an alias for :py:func:`array_empty`.
+    """
+    return array_empty(array)
 
 
 # aggregate functions

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -314,6 +314,10 @@ def py_flatten(arr):
             lambda data: [len(r) == 0 for r in data],
         ],
         [
+            lambda col: f.empty(col),
+            lambda data: [len(r) == 0 for r in data],
+        ],
+        [
             lambda col: f.array_extract(col, literal(1)),
             lambda data: [r[0] for r in data],
         ],


### PR DESCRIPTION
# Which issue does this PR close?

Completes a task in #463

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This PR introduces a new function `empty` as alias of array_empty, to check if an array is empty, returning a boolean.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Added the empty function. 
Updated the Python bindings in functions.py and provided unit tests for empty in test_functions.py.
Updated the documentation (expressions.rst) to include examples on how to use the new empty function.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
The array_empty function is now available for users working with arrays. It is exposed both in Rust and Python, allowing users to check whether arrays are empty within their DataFusion queries.

There are no breaking changes to public APIs.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->