### PR TITLE
README How to develop section now also works on Apple M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ conda env create -f ./conda/environments/datafusion-dev.yaml -n datafusion-dev
 conda activate datafusion-dev
 ```
 
+Or alternatively, if you are on an OS that supports CUDA Toolkit, you can use `-f ./conda/environments/datafusion-cuda-dev.yaml`.
+
 Bootstrap (Pip):
 
 ```bash

--- a/conda/environments/datafusion-cuda-dev.yaml
+++ b/conda/environments/datafusion-cuda-dev.yaml
@@ -38,4 +38,7 @@ dependencies:
   - pydata-sphinx-theme==0.8.0
   - myst-parser
   - jinja2
+  # GPU packages
+  - cudf
+  - cudatoolkit=11.8
 name: datafusion-dev


### PR DESCRIPTION
# Which issue does this PR close?

Closes #939.

 # Rationale for this change
README previously contained instructions that only worked on Linux.

# What changes are included in this PR?
The default Conda environment file no longer depends on CUDA Toolkit or cuDF. An alternative environment file is made available for CUDA support.

# Are there any user-facing changes?
For Apple users, the README will start working. For Linux users where GPUs are supported, the old instructions will not install CUDA support, but alternative instructions are provided to get the old behavior.