### PR TITLE
Add list_cat, list_concat, list_repeat

### DIFF
--- a/docs/source/user-guide/common-operations/expressions.rst
+++ b/docs/source/user-guide/common-operations/expressions.rst
@@ -129,12 +129,12 @@ This function returns a new array with the elements repeated.
 
 .. ipython:: python
 
-    from datafusion import SessionContext, col
+    from datafusion import SessionContext, col, literal
     from datafusion.functions import list_repeat
 
     ctx = SessionContext()
     df = ctx.from_pydict({"a": [[1, 2, 3]]})
-    df.select(list_repeat(col("a"), 2).alias("repeated_array"))
+    df.select(list_repeat(col("a"), literal(2)).alias("repeated_array"))
 
 In this example, the `repeated_array` column will contain `[[1, 2, 3], [1, 2, 3]]`.
 

--- a/docs/source/user-guide/common-operations/expressions.rst
+++ b/docs/source/user-guide/common-operations/expressions.rst
@@ -110,6 +110,35 @@ This function returns an integer indicating the total number of elements in the 
 
 In this example, the `num_elements` column will contain `3` for both rows.
 
+To concatenate two arrays, you can use the function :py:func:`datafusion.functions.list_cat` or :py:func:`datafusion.functions.list_concat`.
+These functions return a new array that is the concatenation of the input arrays.
+
+.. ipython:: python
+
+    from datafusion import SessionContext, col
+    from datafusion.functions import list_cat, list_concat
+
+    ctx = SessionContext()
+    df = ctx.from_pydict({"a": [[1, 2, 3]], "b": [[4, 5, 6]]})
+    df.select(list_cat(col("a"), col("b")).alias("concatenated_array"))
+
+In this example, the `concatenated_array` column will contain `[1, 2, 3, 4, 5, 6]`.
+
+To repeat the elements of an array a specified number of times, you can use the function :py:func:`datafusion.functions.list_repeat`.
+This function returns a new array with the elements repeated.
+
+.. ipython:: python
+
+    from datafusion import SessionContext, col
+    from datafusion.functions import list_repeat
+
+    ctx = SessionContext()
+    df = ctx.from_pydict({"a": [[1, 2, 3]]})
+    df.select(list_repeat(col("a"), 2).alias("repeated_array"))
+
+In this example, the `repeated_array` column will contain `[[1, 2, 3], [1, 2, 3]]`.
+
+
 Structs
 -------
 

--- a/docs/source/user-guide/common-operations/expressions.rst
+++ b/docs/source/user-guide/common-operations/expressions.rst
@@ -110,31 +110,31 @@ This function returns an integer indicating the total number of elements in the 
 
 In this example, the `num_elements` column will contain `3` for both rows.
 
-To concatenate two arrays, you can use the function :py:func:`datafusion.functions.list_cat` or :py:func:`datafusion.functions.list_concat`.
+To concatenate two arrays, you can use the function :py:func:`datafusion.functions.array_cat` or :py:func:`datafusion.functions.array_concat`.
 These functions return a new array that is the concatenation of the input arrays.
 
 .. ipython:: python
 
     from datafusion import SessionContext, col
-    from datafusion.functions import list_cat, list_concat
+    from datafusion.functions import array_cat, array_concat
 
     ctx = SessionContext()
     df = ctx.from_pydict({"a": [[1, 2, 3]], "b": [[4, 5, 6]]})
-    df.select(list_cat(col("a"), col("b")).alias("concatenated_array"))
+    df.select(array_cat(col("a"), col("b")).alias("concatenated_array"))
 
 In this example, the `concatenated_array` column will contain `[1, 2, 3, 4, 5, 6]`.
 
-To repeat the elements of an array a specified number of times, you can use the function :py:func:`datafusion.functions.list_repeat`.
+To repeat the elements of an array a specified number of times, you can use the function :py:func:`datafusion.functions.array_repeat`.
 This function returns a new array with the elements repeated.
 
 .. ipython:: python
 
     from datafusion import SessionContext, col, literal
-    from datafusion.functions import list_repeat
+    from datafusion.functions import array_repeat
 
     ctx = SessionContext()
     df = ctx.from_pydict({"a": [[1, 2, 3]]})
-    df.select(list_repeat(col("a"), literal(2)).alias("repeated_array"))
+    df.select(array_repeat(col("a"), literal(2)).alias("repeated_array"))
 
 In this example, the `repeated_array` column will contain `[[1, 2, 3], [1, 2, 3]]`.
 

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -164,6 +164,7 @@ __all__ = [
     "list_prepend",
     "list_push_back",
     "list_push_front",
+    "list_repeat",
     "list_remove",
     "list_remove_all",
     "list_remove_n",
@@ -1382,6 +1383,14 @@ def list_remove_all(array: Expr, element: Expr) -> Expr:
 def array_repeat(element: Expr, count: Expr) -> Expr:
     """Returns an array containing ``element`` ``count`` times."""
     return Expr(f.array_repeat(element.expr, count.expr))
+
+
+def list_repeat(element: Expr, count: Expr) -> Expr:
+    """Returns an array containing ``element`` ``count`` times.
+
+    This is an alias for :py:func:`array_repeat`.
+    """
+    return array_repeat(element, count)
 
 
 def array_replace(array: Expr, from_val: Expr, to_val: Expr) -> Expr:

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -147,6 +147,8 @@ __all__ = [
     "length",
     "levenshtein",
     "list_append",
+    "list_cat",
+    "list_concat",
     "list_dims",
     "list_distinct",
     "list_element",
@@ -1140,6 +1142,22 @@ def array_dims(array: Expr) -> Expr:
 def array_distinct(array: Expr) -> Expr:
     """Returns distinct values from the array after removing duplicates."""
     return Expr(f.array_distinct(array.expr))
+
+
+def list_cat(*args: Expr) -> Expr:
+    """Concatenates the input arrays.
+
+    This is an alias for :py:func:`array_concat`, :py:func:`array_cat`.
+    """
+    return array_concat(*args)
+
+
+def list_concat(*args: Expr) -> Expr:
+    """Concatenates the input arrays.
+
+    This is an alias for :py:func:`array_concat`, :py:func:`array_cat`.
+    """
+    return array_concat(*args)
 
 
 def list_distinct(array: Expr) -> Expr:

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -290,6 +290,14 @@ def py_flatten(arr):
             lambda data: [np.concatenate([arr, arr]) for arr in data],
         ],
         [
+            lambda col: f.list_cat(col, col),
+            lambda data: [np.concatenate([arr, arr]) for arr in data],
+        ],
+        [
+            lambda col: f.list_concat(col, col),
+            lambda data: [np.concatenate([arr, arr]) for arr in data],
+        ],
+        [
             lambda col: f.array_dims(col),
             lambda data: [[len(r)] for r in data],
         ],

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -446,6 +446,10 @@ def py_flatten(arr):
             lambda data: [[arr] * 2 for arr in data],
         ],
         [
+            lambda col: f.list_repeat(col, literal(2)),
+            lambda data: [[arr] * 2 for arr in data],
+        ],
+        [
             lambda col: f.array_replace(col, literal(3.0), literal(4.0)),
             lambda data: [py_arr_replace(arr, 3.0, 4.0, 1) for arr in data],
         ],


### PR DESCRIPTION
# Which issue does this PR close?

Completes 3 tasks in #463

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This PR adds new functions `list_cat`, `list_concat`, `list_repeat`.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Added the `list_cat`, `list_concat`, `list_repeat` functions.
Updated the Python bindings in functions.py and provided unit tests in test_functions.py.
Updated the documentation (expressions.rst) to include examples on how to use the new functions.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
The list_cat, list_concat, list_repeat functions are now available for users working with arrays allowing users to concatenate and repeat arrays within their DataFusion queries.

There are no breaking changes to public APIs.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->