### PR TITLE
Add datafusion.extract

### DIFF
--- a/docs/source/user-guide/common-operations/functions.rst
+++ b/docs/source/user-guide/common-operations/functions.rst
@@ -82,10 +82,11 @@ Extracting parts of a date using :py:func:`~datafusion.functions.date_part` (ali
 
 .. ipython:: python
 
-    df.select(
-        f.date_part(literal("month"), col('"event_time"')).alias("month"),
-        f.extract(literal("day"), col('"event_time"')).alias("day")
-    )
+     df.select(
+        f.date_part(literal("month"), f.to_timestamp(col('"Total"'))).alias("month"),
+        f.extract(literal("day"), f.to_timestamp(col('"Total"'))).alias("day")
+     )
+  
 String
 ------
 

--- a/docs/source/user-guide/common-operations/functions.rst
+++ b/docs/source/user-guide/common-operations/functions.rst
@@ -78,6 +78,14 @@ Convert to timestamps using :py:func:`~datafusion.functions.to_timestamp`
 
     df.select(f.to_timestamp(col('"Total"')).alias("timestamp"))
 
+Extracting parts of a date using :py:func:`~datafusion.functions.date_part` (alias :py:func:`~datafusion.functions.extract`)
+
+.. ipython:: python
+
+    df.select(
+        f.date_part(literal("month"), col('"event_time"')).alias("month"),
+        f.extract(literal("day"), col('"event_time"')).alias("day")
+    )
 String
 ------
 

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -128,6 +128,7 @@ __all__ = [
     "empty",
     "encode",
     "ends_with",
+    "extract",
     "exp",
     "factorial",
     "find_in_set",
@@ -992,6 +993,14 @@ def datepart(part: Expr, date: Expr) -> Expr:
 def date_part(part: Expr, date: Expr) -> Expr:
     """Extracts a subfield from the date."""
     return Expr(f.date_part(part.expr, date.expr))
+
+
+def extract(part: Expr, date: Expr) -> Expr:
+    """Extracts a subfield from the date.
+
+    This is an alias for :py:func:`date_part`.
+    """
+    return date_part(part, date)
 
 
 def date_trunc(part: Expr, date: Expr) -> Expr:

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -866,6 +866,7 @@ def test_temporal_functions(df):
         f.to_timestamp_seconds(literal("2023-09-07 05:06:14.523952")),
         f.to_timestamp_millis(literal("2023-09-07 05:06:14.523952")),
         f.to_timestamp_micros(literal("2023-09-07 05:06:14.523952")),
+        f.extract(literal("day"), column("d")),
     )
     result = df.collect()
     assert len(result) == 1
@@ -903,6 +904,7 @@ def test_temporal_functions(df):
     assert result.column(9) == pa.array(
         [datetime(2023, 9, 7, 5, 6, 14, 523952)] * 3, type=pa.timestamp("us")
     )
+    assert result.column(10) == pa.array([31, 26, 2], type=pa.float64())
 
 
 def test_case(df):


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Completes a task in #463

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This PR introduces the implementation of the EXTRACT function, which allows extracting specific temporal units (e.g., YEAR, MONTH, DAY) from date or timestamp fields. It is an alias of `date_part`.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Functionality:
Adds the implementation of the EXTRACT subscalar function, it supports extracting temporal units like YEAR, MONTH, DAY, etc., from supported date, timestamp, and time data types.

Tests:
Adds tests for EXTRACT.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes, this PR adds the EXTRACT function to the API, enabling users to perform temporal extraction operations directly.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->