### PR TITLE
Search default window functions if no session context was provided

### DIFF
--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -446,14 +446,14 @@ class DataFrame:
             left_on = join_keys[0]
             right_on = join_keys[1]
 
-        if on:
-            if left_on or right_on:
+        if on is not None:
+            if left_on is not None or right_on is not None:
                 raise ValueError(
                     "`left_on` or `right_on` should not provided with `on`"
                 )
             left_on = on
             right_on = on
-        elif left_on or right_on:
+        elif left_on is not None or right_on is not None:
             if left_on is None or right_on is None:
                 raise ValueError("`left_on` and `right_on` should both be provided.")
         else:

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -431,6 +431,7 @@ def window(
     partition_by = expr_list_to_raw_expr_list(partition_by)
     order_by_raw = sort_list_to_raw_sort_list(order_by)
     window_frame = window_frame.window_frame if window_frame is not None else None
+    ctx = ctx.ctx if ctx is not None else None
     return Expr(f.window(name, args, partition_by, order_by_raw, window_frame, ctx))
 
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use datafusion::functions_aggregate::all_default_aggregate_functions;
+use datafusion::functions_window::all_default_window_functions;
 use datafusion::logical_expr::ExprFunctionExt;
 use datafusion::logical_expr::WindowFrame;
 use pyo3::{prelude::*, wrap_pyfunction};
@@ -280,6 +281,16 @@ fn find_window_fn(name: &str, ctx: Option<PySessionContext>) -> PyResult<WindowF
 
     if let Some(agg_fn) = agg_fn {
         return Ok(agg_fn);
+    }
+
+    // search default window functions
+    let window_fn = all_default_window_functions()
+        .iter()
+        .find(|v| v.name() == name || v.aliases().contains(&name.to_string()))
+        .map(|f| WindowFunctionDefinition::WindowUDF(f.clone()));
+
+    if let Some(window_fn) = window_fn {
+        return Ok(window_fn);
     }
 
     Err(DataFusionError::Common(format!("window function `{name}` not found")).into())


### PR DESCRIPTION
# Which issue does this PR close?

None

 # Rationale for this change

During testing of the DF 43.0.0 release we discovered that the `datafusion.functions.window` would fail to find default window functions if a session context is not provided.

# What changes are included in this PR?

Search for default window functions in addition to default aggregate functions.

# Are there any user-facing changes?

None, internal only.