### PR TITLE
Support async iteration of RecordBatchStream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,6 +1303,7 @@ dependencies = [
  "prost",
  "prost-types",
  "pyo3",
+ "pyo3-async-runtimes",
  "pyo3-build-config",
  "tokio",
  "url",
@@ -2670,6 +2671,19 @@ dependencies = [
  "pyo3-ffi",
  "pyo3-macros",
  "unindent",
+]
+
+[[package]]
+name = "pyo3-async-runtimes"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2529f0be73ffd2be0cc43c013a640796558aa12d7ca0aab5cc14f375b4733031"
+dependencies = [
+ "futures",
+ "once_cell",
+ "pin-project-lite",
+ "pyo3",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ substrait = ["dep:datafusion-substrait"]
 [dependencies]
 tokio = { version = "1.41", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3", "abi3-py38"] }
+pyo3-async-runtimes = { version = "0.22", features = ["tokio-runtime"]}
 arrow = { version = "53", features = ["pyarrow"] }
 datafusion = { version = "43.0.0", features = ["pyarrow", "avro", "unicode_expressions"] }
 datafusion-substrait = { version = "43.0.0", optional = true }

--- a/python/datafusion/record_batch.py
+++ b/python/datafusion/record_batch.py
@@ -63,7 +63,7 @@ class RecordBatchStream:
 
     async def __anext__(self) -> RecordBatch:
         """Async iterator function."""
-        next_batch = self.rbs.__anext__()
+        next_batch = await self.rbs.__anext__()
         return RecordBatch(next_batch)
 
     def __next__(self) -> RecordBatch:

--- a/python/datafusion/record_batch.py
+++ b/python/datafusion/record_batch.py
@@ -59,17 +59,21 @@ class RecordBatchStream:
 
     def next(self) -> RecordBatch | None:
         """See :py:func:`__next__` for the iterator function."""
-        try:
-            next_batch = next(self)
-        except StopIteration:
-            return None
+        return next(self)
 
-        return next_batch
+    async def __anext__(self) -> RecordBatch:
+        """Async iterator function."""
+        next_batch = anext(self.rbs)
+        return RecordBatch(next_batch)
 
     def __next__(self) -> RecordBatch:
         """Iterator function."""
         next_batch = next(self.rbs)
         return RecordBatch(next_batch)
+
+    def __aiter__(self) -> typing_extensions.Self:
+        """Async iterator function."""
+        return self
 
     def __iter__(self) -> typing_extensions.Self:
         """Iterator function."""

--- a/python/datafusion/record_batch.py
+++ b/python/datafusion/record_batch.py
@@ -57,7 +57,7 @@ class RecordBatchStream:
         """This constructor is typically not called by the end user."""
         self.rbs = record_batch_stream
 
-    def next(self) -> RecordBatch | None:
+    def next(self) -> RecordBatch:
         """See :py:func:`__next__` for the iterator function."""
         return next(self)
 

--- a/python/datafusion/record_batch.py
+++ b/python/datafusion/record_batch.py
@@ -63,7 +63,7 @@ class RecordBatchStream:
 
     async def __anext__(self) -> RecordBatch:
         """Async iterator function."""
-        next_batch = anext(self.rbs)
+        next_batch = self.rbs.__anext__()
         return RecordBatch(next_batch)
 
     def __next__(self) -> RecordBatch:

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -761,8 +761,8 @@ def test_execution_plan(aggregate_df):
     batch = stream.next()
     assert batch is not None
     # there should be no more batches
-    batch = stream.next()
-    assert batch is None
+    with pytest.raises(StopIteration):
+        stream.next()
 
 
 def test_repartition(df):


### PR DESCRIPTION
# Which issue does this PR close?

Closes #974 .

# Rationale for this change

Support async iteration of RecordBatchStream.

# What changes are included in this PR?

- Move into Rust raising `StopIteration` or `AsyncStopIteration` errors
- Update typing
- Add dependency on pyo3-async-runtimes to manage future conversion.
- Move `SendableRecordBatchStream` into an `Arc<Mutex<>>`. This is required I think so that we can clone the stream into `future_into_py`

# Are there any user-facing changes?

Adds async iterator support.
