### PR TITLE
Default to ZSTD compression when writing Parquet 

### DIFF
--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -68,6 +68,9 @@ class Compression(Enum):
         Args:
             value: The string representation of the compression type.
 
+        Returns:
+            The Compression enum lowercase value.
+
         Raises:
             ValueError: If the string does not match any Compression enum value.
         """
@@ -79,7 +82,11 @@ class Compression(Enum):
             )
 
     def get_default_level(self) -> Optional[int]:
-        """Get the default compression level for the compression type."""
+        """Get the default compression level for the compression type.
+
+        Returns:
+            The default compression level for the compression type.
+        """
         # GZIP, BROTLI default values from deltalake repo
         # https://github.com/apache/datafusion-python/pull/981#discussion_r1905619163
         # ZSTD default value from delta-rs

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -632,9 +632,10 @@ class DataFrame:
             recommended range is 1 to 22, with the default being 3. Higher levels
             provide better compression but slower speed.
         """
-        # default compression level to 3 for ZSTD
         if compression == "ZSTD":
             if compression_level is None:
+                # Default compression level for ZSTD is 3 as per
+                # https://facebook.github.io/zstd/zstd_manual.html
                 compression_level = 3
             elif not (1 <= compression_level <= 22):
                 raise ValueError("Compression level for ZSTD must be between 1 and 22")

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -41,6 +41,8 @@ from enum import Enum
 # excerpt from deltalake
 # https://github.com/apache/datafusion-python/pull/981#discussion_r1905619163
 class Compression(Enum):
+    """Enum representing the available compression types for Parquet files."""
+
     UNCOMPRESSED = "uncompressed"
     SNAPPY = "snappy"
     GZIP = "gzip"
@@ -52,6 +54,17 @@ class Compression(Enum):
 
     @classmethod
     def from_str(cls, value: str) -> "Compression":
+        """Convert a string to a Compression enum value.
+
+        Args:
+            value (str): The string representation of the compression type.
+
+        Returns:
+            Compression: The corresponding Compression enum value.
+
+        Raises:
+            ValueError: If the string does not match any Compression enum value.
+        """
         try:
             return cls(value.lower())
         except ValueError:
@@ -60,6 +73,14 @@ class Compression(Enum):
             )
 
     def get_default_level(self) -> int:
+        """Get the default compression level for the compression type.
+
+        Returns:
+            int: The default compression level.
+
+        Raises:
+            KeyError: If the compression type does not have a default level.
+        """
         # GZIP, BROTLI defaults from deltalake
         # https://github.com/apache/datafusion-python/pull/981#discussion_r1905619163
         if self == Compression.GZIP:

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -620,16 +620,24 @@ class DataFrame:
     def write_parquet(
         self,
         path: str | pathlib.Path,
-        compression: str = "uncompressed",
+        compression: str = "ZSTD",
         compression_level: int | None = None,
     ) -> None:
         """Execute the :py:class:`DataFrame` and write the results to a Parquet file.
 
         Args:
-            path: Path of the Parquet file to write.
-            compression: Compression type to use.
-            compression_level: Compression level to use.
+        path (str | pathlib.Path): The file path to write the Parquet file.
+        compression (str): The compression algorithm to use. Default is "ZSTD".
+        compression_level (int | None): The compression level to use. For ZSTD, the
+            recommended range is 1 to 22, with the default being 3. Higher levels
+            provide better compression but slower speed.
         """
+        # default compression level to 3 for ZSTD
+        if compression == "ZSTD":
+            if compression_level is None:
+                compression_level = 3
+            elif not (1 <= compression_level <= 22):
+                raise ValueError("Compression level for ZSTD must be between 1 and 22")
         self.df.write_parquet(str(path), compression, compression_level)
 
     def write_json(self, path: str | pathlib.Path) -> None:

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -38,6 +38,8 @@ from datafusion.expr import Expr, SortExpr, sort_or_default
 from enum import Enum
 
 
+# excerpt from deltalake
+# https://github.com/apache/datafusion-python/pull/981#discussion_r1905619163
 class Compression(Enum):
     UNCOMPRESSED = "uncompressed"
     SNAPPY = "snappy"
@@ -58,11 +60,15 @@ class Compression(Enum):
             )
 
     def get_default_level(self) -> int:
+        # GZIP, BROTLI defaults from deltalake
+        # https://github.com/apache/datafusion-python/pull/981#discussion_r1905619163
         if self == Compression.GZIP:
             DEFAULT = 6
         elif self == Compression.BROTLI:
             DEFAULT = 1
         elif self == Compression.ZSTD:
+            # ZSTD default from delta-rs
+            # https://github.com/apache/datafusion-python/pull/981#discussion_r1904789223
             DEFAULT = 4
         else:
             raise KeyError(f"{self.value} does not have a compression level.")

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -661,14 +661,14 @@ class DataFrame:
             path: Path of the Parquet file to write.
             compression: Compression type to use. Default is "ZSTD".
                 Available compression types are:
-                - "UNCOMPRESSED": No compression.
-                - "SNAPPY": Snappy compression.
-                - "GZIP": Gzip compression.
-                - "BROTLI": Brotli compression.
-                - "LZ0": LZ0 compression.
-                - "LZ4": LZ4 compression.
-                - "LZ4_RAW": LZ4_RAW compression.
-                - "ZSTD": Zstandard compression.
+                - "uncompressed": No compression.
+                - "snappy": Snappy compression.
+                - "gzip": Gzip compression.
+                - "brotli": Brotli compression.
+                - "lz0": LZ0 compression.
+                - "lz4": LZ4 compression.
+                - "lz4_raw": LZ4_RAW compression.
+                - "zstd": Zstandard compression.
             compression_level: Compression level to use. For ZSTD, the
                 recommended range is 1 to 22, with the default being 4. Higher levels
                 provide better compression but slower speed.

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -36,7 +36,6 @@ if TYPE_CHECKING:
 from datafusion._internal import DataFrame as DataFrameInternal
 from datafusion.expr import Expr, SortExpr, sort_or_default
 from enum import Enum
-from typing import Tuple
 
 
 class Compression(Enum):

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -629,14 +629,14 @@ class DataFrame:
         path (str | pathlib.Path): The file path to write the Parquet file.
         compression (str): The compression algorithm to use. Default is "ZSTD".
         compression_level (int | None): The compression level to use. For ZSTD, the
-            recommended range is 1 to 22, with the default being 3. Higher levels
+            recommended range is 1 to 22, with the default being 4. Higher levels
             provide better compression but slower speed.
         """
         if compression == "ZSTD":
             if compression_level is None:
-                # Default compression level for ZSTD is 3 as per
-                # https://facebook.github.io/zstd/zstd_manual.html
-                compression_level = 3
+                # Default compression level for ZSTD is 4 like in delta-rs
+                # https://github.com/apache/datafusion-python/pull/981#discussion_r1899871918
+                compression_level = 4
             elif not (1 <= compression_level <= 22):
                 raise ValueError("Compression level for ZSTD must be between 1 and 22")
         self.df.write_parquet(str(path), compression, compression_level)

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -626,11 +626,11 @@ class DataFrame:
         """Execute the :py:class:`DataFrame` and write the results to a Parquet file.
 
         Args:
-        path (str | pathlib.Path): The file path to write the Parquet file.
-        compression (str): The compression algorithm to use. Default is "ZSTD".
-        compression_level (int | None): The compression level to use. For ZSTD, the
-            recommended range is 1 to 22, with the default being 4. Higher levels
-            provide better compression but slower speed.
+            path: Path of the Parquet file to write.
+            compression: Compression type to use. Default is "ZSTD".
+            compression_level: Compression level to use. For ZSTD, the
+                recommended range is 1 to 22, with the default being 4. Higher levels
+                provide better compression but slower speed.
         """
         if compression == "ZSTD":
             if compression_level is None:

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -1113,11 +1113,11 @@ def test_write_compressed_parquet_invalid_compression(df, tmp_path, compression)
         df.write_parquet(str(path), compression=compression)
 
 
-# Test write_parquet with zstd, brotli, gzip default compression level,
-# ie don't specify compression level
-# should complete without error
 @pytest.mark.parametrize("compression", ["zstd", "brotli", "gzip"])
 def test_write_compressed_parquet_default_compression_level(df, tmp_path, compression):
+    # Test write_parquet with zstd, brotli, gzip default compression level,
+    # ie don't specify compression level
+    # should complete without error
     path = tmp_path
 
     df.write_parquet(str(path), compression=compression)

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -731,7 +731,9 @@ def test_optimized_logical_plan(aggregate_df):
 def test_execution_plan(aggregate_df):
     plan = aggregate_df.execution_plan()
 
-    expected = "AggregateExec: mode=FinalPartitioned, gby=[c1@0 as c1], aggr=[sum(test.c2)]\n"  # noqa: E501
+    expected = (
+        "AggregateExec: mode=FinalPartitioned, gby=[c1@0 as c1], aggr=[sum(test.c2)]\n"  # noqa: E501
+    )
 
     assert expected == plan.display()
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -1105,20 +1105,20 @@ def test_write_compressed_parquet_wrong_compression_level(
         )
 
 
+@pytest.mark.parametrize("compression", ["wrong"])
+def test_write_compressed_parquet_invalid_compression(df, tmp_path, compression):
+    path = tmp_path
+
+    with pytest.raises(ValueError):
+        df.write_parquet(str(path), compression=compression)
+
+
 # test write_parquet with zstd, brotli default compression level, should complete without error
 @pytest.mark.parametrize("compression", ["zstd", "brotli"])
 def test_write_compressed_parquet_default_compression_level(df, tmp_path, compression):
     path = tmp_path
 
     df.write_parquet(str(path), compression=compression)
-
-
-@pytest.mark.parametrize("compression", ["wrong"])
-def test_write_compressed_parquet_missing_compression_level(df, tmp_path, compression):
-    path = tmp_path
-
-    with pytest.raises(ValueError):
-        df.write_parquet(str(path), compression=compression)
 
 
 def test_dataframe_export(df) -> None:

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -1113,10 +1113,10 @@ def test_write_compressed_parquet_invalid_compression(df, tmp_path, compression)
         df.write_parquet(str(path), compression=compression)
 
 
-# Test write_parquet with zstd, brotli default compression level,
+# Test write_parquet with zstd, brotli, gzip default compression level,
 # ie don't specify compression level
 # should complete without error
-@pytest.mark.parametrize("compression", ["zstd", "brotli"])
+@pytest.mark.parametrize("compression", ["zstd", "brotli", "gzip"])
 def test_write_compressed_parquet_default_compression_level(df, tmp_path, compression):
     path = tmp_path
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -731,9 +731,7 @@ def test_optimized_logical_plan(aggregate_df):
 def test_execution_plan(aggregate_df):
     plan = aggregate_df.execution_plan()
 
-    expected = (
-        "AggregateExec: mode=FinalPartitioned, gby=[c1@0 as c1], aggr=[sum(test.c2)]\n"  # noqa: E501
-    )
+    expected = "AggregateExec: mode=FinalPartitioned, gby=[c1@0 as c1], aggr=[sum(test.c2)]\n"  # noqa: E501
 
     assert expected == plan.display()
 
@@ -1107,7 +1105,15 @@ def test_write_compressed_parquet_wrong_compression_level(
         )
 
 
-@pytest.mark.parametrize("compression", ["brotli", "zstd", "wrong"])
+# test write_parquet with zstd, brotli default compression level, should complete without error
+@pytest.mark.parametrize("compression", ["zstd", "brotli"])
+def test_write_compressed_parquet_default_compression_level(df, tmp_path, compression):
+    path = tmp_path
+
+    df.write_parquet(str(path), compression=compression)
+
+
+@pytest.mark.parametrize("compression", ["wrong"])
 def test_write_compressed_parquet_missing_compression_level(df, tmp_path, compression):
     path = tmp_path
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -1113,7 +1113,9 @@ def test_write_compressed_parquet_invalid_compression(df, tmp_path, compression)
         df.write_parquet(str(path), compression=compression)
 
 
-# test write_parquet with zstd, brotli default compression level, should complete without error
+# Test write_parquet with zstd, brotli default compression level,
+# ie don't specify compression level
+# should complete without error
 @pytest.mark.parametrize("compression", ["zstd", "brotli"])
 def test_write_compressed_parquet_default_compression_level(df, tmp_path, compression):
     path = tmp_path

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -463,7 +463,7 @@ impl PyDataFrame {
     /// Write a `DataFrame` to a Parquet file.
     #[pyo3(signature = (
         path,
-        compression="uncompressed",
+        compression="zstd",
         compression_level=None
         ))]
     fn write_parquet(


### PR DESCRIPTION

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #978.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently, the write_parquet method defaults to "uncompressed" Parquet files, which can lead to inefficient storage and slower performance during I/O operations. This change sets the default compression method to "ZSTD", a modern compression algorithm that provides an excellent balance of compression speed and ratio. Additionally, it introduces a default compression level of 3 for ZSTD, which is optimal for many use cases.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Updated the default compression parameter in the write_parquet method from "uncompressed" to "ZSTD".
Introduced a default compression level of 3 for ZSTD if no level is specified.
Added validation to ensure the compression level for ZSTD falls within the valid range (1 to 22) and raises a ValueError otherwise.
Updated the docstring to clarify the default values and provide guidance for users on compression levels.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes:

The default behavior of write_parquet now compresses output files using ZSTD with a default compression level of 3, instead of leaving files uncompressed.
Users specifying an invalid compression level for ZSTD will now encounter a ValueError.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->