### PR TITLE
expose write options

### DIFF
--- a/python/datafusion/options.py
+++ b/python/datafusion/options.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Option conversion functions."""
+
+from typing import Optional, Dict
+from datafusion.expr import sort_list_to_raw_sort_list
+
+
+def write_options_to_raw_write_options(write_options: Optional[Dict]) -> Dict:
+    """Convert a dictionary of write options into the format expected by the pyo3 bindings.
+    Validates that no superfluous keys are specified, then:
+    - adds default keys for each expected write option.
+    - converts "sort_by" into a raw sort list.
+    """
+    defaults = {
+        "insert_operation": None,
+        "single_file_output": None,
+        "partition_by": None,
+        "sort_by": None,
+    }
+
+    if write_options is not None:
+        invalid_write_options = set(write_options) - set(defaults)
+        if invalid_write_options:
+            raise ValueError(f"Invalid write options: {invalid_write_options}")
+
+        results = {**defaults, **write_options}
+        if "sort_by" in write_options:
+            results["sort_by"] = sort_list_to_raw_sort_list(write_options["sort_by"])
+
+        return results
+    else:
+        return defaults

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ mod record_batch;
 pub mod sql;
 pub mod store;
 
+mod options;
 #[cfg(feature = "substrait")]
 pub mod substrait;
 #[allow(clippy::borrow_deref_ref)]

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion::{dataframe::DataFrameWriteOptions, logical_expr::dml::InsertOp};
+use pyo3::{exceptions::PyValueError, FromPyObject, PyErr, PyResult};
+
+use crate::expr::sort_expr::{to_sort_expressions, PySortExpr};
+
+#[derive(FromPyObject)]
+#[pyo3(from_item_all)]
+pub struct PyDataFrameWriteOptions {
+    insert_operation: Option<String>,
+    single_file_output: Option<bool>,
+    partition_by: Option<Vec<String>>,
+    sort_by: Option<Vec<PySortExpr>>,
+}
+
+impl TryInto<DataFrameWriteOptions> for PyDataFrameWriteOptions {
+    type Error = PyErr;
+
+    fn try_into(self) -> PyResult<DataFrameWriteOptions> {
+        let mut options = DataFrameWriteOptions::new();
+        if let Some(insert_op) = self.insert_operation {
+            let op = match insert_op.as_str() {
+                "append" => InsertOp::Append,
+                "overwrite" => InsertOp::Overwrite,
+                "replace" => InsertOp::Replace,
+                _ => {
+                    return Err(PyValueError::new_err(format!(
+                        "Unrecognized insert op {insert_op}"
+                    )))
+                }
+            };
+            options = options.with_insert_operation(op);
+        }
+        if let Some(single_file_output) = self.single_file_output {
+            options = options.with_single_file_output(single_file_output);
+        }
+
+        if let Some(partition_by) = self.partition_by {
+            options = options.with_partition_by(partition_by);
+        }
+
+        if let Some(sort_by) = self.sort_by {
+            options = options.with_sort_by(to_sort_expressions(sort_by));
+        }
+
+        Ok(options)
+    }
+}
+
+pub fn make_dataframe_write_options(
+    write_options: Option<PyDataFrameWriteOptions>,
+) -> PyResult<DataFrameWriteOptions> {
+    if let Some(wo) = write_options {
+        wo.try_into()
+    } else {
+        Ok(DataFrameWriteOptions::new())
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?
Closes #1005 .

This is still a draft. Todo list:
- [x] `DataFrameWriteOptions`
- [ ] CsvOptions
- [ ] JsonOptions
- [ ] TableParquetOptions

# What changes are included in this PR?
`dataframe.write_csv(...)`, `dataframe.write_json(...)` and `dataframe.write_parquet` now take an additional optional argument `write_options`, corresponding with `DataFrameWriteOptions` in datafusion. This is a dictionary with the following optional keys:
- "insert_operation": one of "append", "overwrite" or "replace", corresponding to `InsertOp` in datafusion.
- "single_file_option": a boolean
- "partition_by": list of strings, names of columns to hive partition on
- "sort_by": list of sort expressions

# Are there any user-facing changes?
