### PR TITLE
Fix verify-release-candidate script by removing reference to requirements-310.txt

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -128,7 +128,6 @@ test_source_distribution() {
   python3 -m venv .venv
   source .venv/bin/activate
   python3 -m pip install -U pip
-  python3 -m pip install -r requirements-310.txt
   maturin develop
 
   #TODO: we should really run tests here as well

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -128,6 +128,7 @@ test_source_distribution() {
   python3 -m venv .venv
   source .venv/bin/activate
   python3 -m pip install -U pip
+  python3 -m pip install -U maturin
   maturin develop
 
   #TODO: we should really run tests here as well


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
When verifying the release using `./dev/release/verify_release_candidate.sh 44.0.0 1`  I got the following error

```
Requirement already satisfied: pip in ./.venv/lib/python3.11/site-packages (24.3.1)
Collecting pip
  Using cached pip-25.0-py3-none-any.whl.metadata (3.7 kB)
Using cached pip-25.0-py3-none-any.whl (1.8 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 24.3.1
    Uninstalling pip-24.3.1:
      Successfully uninstalled pip-24.3.1
Successfully installed pip-25.0
+ python3 -m pip install -r requirements-310.txt
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements-310.txt'
+ cleanup
+ '[' no = yes ']'
+ echo 'Failed to verify release candidate. See /var/folders/1l/tg68jc6550gg8xqf1hr4mlwr0000gn/T/datafusion-python-44.0.0.XXXXX.r7zw2OmGe9 for details.'
Failed to verify release candidate. See /var/folders/1l/tg68jc6550gg8xqf1hr4mlwr0000gn/T/datafusion-python-44.0.0.XXXXX.r7zw2OmGe9 for details.
```

When I commented out the line everything worked great

See the email list for more information: https://lists.apache.org/thread/gkk4lq6k19gcq9xw64mcmbxrnf68o95s

# What changes are included in this PR?
Remove line that was erroring

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->