### PR TITLE
fix: add to_timestamp_nanos

### DIFF
--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -252,6 +252,7 @@ __all__ = [
     "to_hex",
     "to_timestamp",
     "to_timestamp_micros",
+    "to_timestamp_nanos",
     "to_timestamp_millis",
     "to_timestamp_seconds",
     "to_unixtime",

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -871,6 +871,7 @@ def test_temporal_functions(df):
         f.to_timestamp_millis(literal("2023-09-07 05:06:14.523952")),
         f.to_timestamp_micros(literal("2023-09-07 05:06:14.523952")),
         f.extract(literal("day"), column("d")),
+        f.to_timestamp_nanos(literal("2023-09-07 05:06:14.523952")),
     )
     result = df.collect()
     assert len(result) == 1
@@ -909,6 +910,9 @@ def test_temporal_functions(df):
         [datetime(2023, 9, 7, 5, 6, 14, 523952)] * 3, type=pa.timestamp("us")
     )
     assert result.column(10) == pa.array([31, 26, 2], type=pa.int32())
+    assert result.column(11) == pa.array(
+        [datetime(2023, 9, 7, 5, 6, 14, 523952)] * 3, type=pa.timestamp("ns")
+    )
 
 
 def test_arrow_cast(df):

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -553,6 +553,7 @@ expr_fn!(
 expr_fn!(now);
 expr_fn_vec!(to_timestamp);
 expr_fn_vec!(to_timestamp_millis);
+expr_fn_vec!(to_timestamp_nanos);
 expr_fn_vec!(to_timestamp_micros);
 expr_fn_vec!(to_timestamp_seconds);
 expr_fn_vec!(to_unixtime);
@@ -977,6 +978,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(to_hex))?;
     m.add_wrapped(wrap_pyfunction!(to_timestamp))?;
     m.add_wrapped(wrap_pyfunction!(to_timestamp_millis))?;
+    m.add_wrapped(wrap_pyfunction!(to_timestamp_nanos))?;
     m.add_wrapped(wrap_pyfunction!(to_timestamp_micros))?;
     m.add_wrapped(wrap_pyfunction!(to_timestamp_seconds))?;
     m.add_wrapped(wrap_pyfunction!(to_unixtime))?;


### PR DESCRIPTION
# Which issue does this PR close?

No

 # Rationale for this change

to_timestamp_nanos has a wrapper, but not exported from rust.

# What changes are included in this PR?

export to_timestamp_nanos to python

# Are there any user-facing changes?

no
