### PR TITLE
pyo3 update required changes to deprecated interfaces

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,14 +47,14 @@ impl PyConfig {
     }
 
     /// Get a configuration option
-    pub fn get(&mut self, key: &str, py: Python) -> PyResult<PyObject> {
+    pub fn get<'py>(&mut self, key: &str, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let options = self.config.to_owned();
         for entry in options.entries() {
             if entry.key == key {
-                return Ok(entry.value.into_py(py));
+                return Ok(entry.value.into_pyobject(py)?);
             }
         }
-        Ok(None::<String>.into_py(py))
+        Ok(None::<String>.into_pyobject(py)?)
     }
 
     /// Set a configuration option
@@ -66,10 +66,10 @@ impl PyConfig {
 
     /// Get all configuration options
     pub fn get_all(&mut self, py: Python) -> PyResult<PyObject> {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         let options = self.config.to_owned();
         for entry in options.entries() {
-            dict.set_item(entry.key, entry.value.clone().into_py(py))?;
+            dict.set_item(entry.key, entry.value.clone().into_pyobject(py)?)?;
         }
         Ok(dict.into())
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -458,8 +458,8 @@ impl PySessionContext {
         let py = data.py();
 
         // Instantiate pyarrow Table object & convert to Arrow Table
-        let table_class = py.import_bound("pyarrow")?.getattr("Table")?;
-        let args = PyTuple::new_bound(py, &[data]);
+        let table_class = py.import("pyarrow")?.getattr("Table")?;
+        let args = PyTuple::new(py, &[data])?;
         let table = table_class.call_method1("from_pylist", args)?;
 
         // Convert Arrow Table to datafusion DataFrame
@@ -478,8 +478,8 @@ impl PySessionContext {
         let py = data.py();
 
         // Instantiate pyarrow Table object & convert to Arrow Table
-        let table_class = py.import_bound("pyarrow")?.getattr("Table")?;
-        let args = PyTuple::new_bound(py, &[data]);
+        let table_class = py.import("pyarrow")?.getattr("Table")?;
+        let args = PyTuple::new(py, &[data])?;
         let table = table_class.call_method1("from_pydict", args)?;
 
         // Convert Arrow Table to datafusion DataFrame
@@ -533,8 +533,8 @@ impl PySessionContext {
         let py = data.py();
 
         // Instantiate pyarrow Table object & convert to Arrow Table
-        let table_class = py.import_bound("pyarrow")?.getattr("Table")?;
-        let args = PyTuple::new_bound(py, &[data]);
+        let table_class = py.import("pyarrow")?.getattr("Table")?;
+        let args = PyTuple::new(py, &[data])?;
         let table = table_class.call_method1("from_pandas", args)?;
 
         // Convert Arrow Table to datafusion DataFrame

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -545,12 +545,12 @@ impl PyDataFrame {
     /// Convert to Arrow Table
     /// Collect the batches and pass to Arrow Table
     fn to_arrow_table(&self, py: Python<'_>) -> PyResult<PyObject> {
-        let batches = self.collect(py)?.to_object(py);
-        let schema: PyObject = self.schema().into_pyobject(py)?.to_object(py);
+        let batches = self.collect(py)?.into_pyobject(py)?;
+        let schema = self.schema().into_pyobject(py)?;
 
         // Instantiate pyarrow Table object and use its from_batches method
-        let table_class = py.import_bound("pyarrow")?.getattr("Table")?;
-        let args = PyTuple::new_bound(py, &[batches, schema]);
+        let table_class = py.import("pyarrow")?.getattr("Table")?;
+        let args = PyTuple::new(py, &[batches, schema])?;
         let table: PyObject = table_class.call_method1("from_batches", args)?.into();
         Ok(table)
     }
@@ -585,8 +585,7 @@ impl PyDataFrame {
 
         let ffi_stream = FFI_ArrowArrayStream::new(reader);
         let stream_capsule_name = CString::new("arrow_array_stream").unwrap();
-        PyCapsule::new_bound(py, ffi_stream, Some(stream_capsule_name))
-            .map_err(PyDataFusionError::from)
+        PyCapsule::new(py, ffi_stream, Some(stream_capsule_name)).map_err(PyDataFusionError::from)
     }
 
     fn execute_stream(&self, py: Python) -> PyDataFusionResult<PyRecordBatchStream> {
@@ -649,8 +648,8 @@ impl PyDataFrame {
     /// Collect the batches, pass to Arrow Table & then convert to polars DataFrame
     fn to_polars(&self, py: Python<'_>) -> PyResult<PyObject> {
         let table = self.to_arrow_table(py)?;
-        let dataframe = py.import_bound("polars")?.getattr("DataFrame")?;
-        let args = PyTuple::new_bound(py, &[table]);
+        let dataframe = py.import("polars")?.getattr("DataFrame")?;
+        let args = PyTuple::new(py, &[table])?;
         let result: PyObject = dataframe.call1(args)?.into();
         Ok(result)
     }
@@ -673,7 +672,7 @@ fn print_dataframe(py: Python, df: DataFrame) -> PyDataFusionResult<()> {
 
     // Import the Python 'builtins' module to access the print function
     // Note that println! does not print to the Python debug console and is not visible in notebooks for instance
-    let print = py.import_bound("builtins")?.getattr("print")?;
+    let print = py.import("builtins")?.getattr("print")?;
     print.call1((result,))?;
     Ok(())
 }

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -48,7 +48,7 @@ impl Dataset {
     // Creates a Python PyArrow.Dataset
     pub fn new(dataset: &Bound<'_, PyAny>, py: Python) -> PyResult<Self> {
         // Ensure that we were passed an instance of pyarrow.dataset.Dataset
-        let ds = PyModule::import_bound(py, "pyarrow.dataset")?;
+        let ds = PyModule::import(py, "pyarrow.dataset")?;
         let ds_attr = ds.getattr("Dataset")?;
         let ds_type = ds_attr.downcast::<PyType>()?;
         if dataset.is_instance(ds_type)? {

--- a/src/dataset_exec.rs
+++ b/src/dataset_exec.rs
@@ -104,7 +104,7 @@ impl DatasetExec {
             })
             .transpose()?;
 
-        let kwargs = PyDict::new_bound(py);
+        let kwargs = PyDict::new(py);
 
         kwargs.set_item("columns", columns.clone())?;
         kwargs.set_item(
@@ -121,7 +121,7 @@ impl DatasetExec {
                 .0,
         );
 
-        let builtins = Python::import_bound(py, "builtins")?;
+        let builtins = Python::import(py, "builtins")?;
         let pylist = builtins.getattr("list")?;
 
         // Get the fragments or partitions of the dataset
@@ -198,7 +198,7 @@ impl ExecutionPlan for DatasetExec {
             let dataset_schema = dataset
                 .getattr("schema")
                 .map_err(|err| InnerDataFusionError::External(Box::new(err)))?;
-            let kwargs = PyDict::new_bound(py);
+            let kwargs = PyDict::new(py);
             kwargs
                 .set_item("columns", self.columns.clone())
                 .map_err(|err| InnerDataFusionError::External(Box::new(err)))?;
@@ -223,7 +223,7 @@ impl ExecutionPlan for DatasetExec {
             let record_batches: Bound<'_, PyIterator> = scanner
                 .call_method0("to_batches")
                 .map_err(|err| InnerDataFusionError::External(Box::new(err)))?
-                .iter()
+                .try_iter()
                 .map_err(|err| InnerDataFusionError::External(Box::new(err)))?;
 
             let record_batches = PyArrowBatchesAdapter {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -91,3 +91,7 @@ pub fn py_datafusion_err(e: impl Debug) -> PyErr {
 pub fn py_unsupported_variant_err(e: impl Debug) -> PyErr {
     PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("{e:?}"))
 }
+
+pub fn to_datafusion_err(e: impl Debug) -> InnerDataFusionError {
+    InnerDataFusionError::Execution(format!("{e:?}"))
+}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -19,6 +19,7 @@ use datafusion::logical_expr::utils::exprlist_to_fields;
 use datafusion::logical_expr::{
     ExprFuncBuilder, ExprFunctionExt, LogicalPlan, WindowFunctionDefinition,
 };
+use pyo3::IntoPyObjectExt;
 use pyo3::{basic::CompareOp, prelude::*};
 use std::convert::{From, Into};
 use std::sync::Arc;
@@ -126,35 +127,35 @@ pub fn py_expr_list(expr: &[Expr]) -> PyResult<Vec<PyExpr>> {
 #[pymethods]
 impl PyExpr {
     /// Return the specific expression
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         Python::with_gil(|_| {
             match &self.expr {
-            Expr::Alias(alias) => Ok(PyAlias::from(alias.clone()).into_py(py)),
-            Expr::Column(col) => Ok(PyColumn::from(col.clone()).into_py(py)),
+            Expr::Alias(alias) => Ok(PyAlias::from(alias.clone()).into_bound_py_any(py)?),
+            Expr::Column(col) => Ok(PyColumn::from(col.clone()).into_bound_py_any(py)?),
             Expr::ScalarVariable(data_type, variables) => {
-                Ok(PyScalarVariable::new(data_type, variables).into_py(py))
+                Ok(PyScalarVariable::new(data_type, variables).into_bound_py_any(py)?)
             }
-            Expr::Like(value) => Ok(PyLike::from(value.clone()).into_py(py)),
-            Expr::Literal(value) => Ok(PyLiteral::from(value.clone()).into_py(py)),
-            Expr::BinaryExpr(expr) => Ok(PyBinaryExpr::from(expr.clone()).into_py(py)),
-            Expr::Not(expr) => Ok(PyNot::new(*expr.clone()).into_py(py)),
-            Expr::IsNotNull(expr) => Ok(PyIsNotNull::new(*expr.clone()).into_py(py)),
-            Expr::IsNull(expr) => Ok(PyIsNull::new(*expr.clone()).into_py(py)),
-            Expr::IsTrue(expr) => Ok(PyIsTrue::new(*expr.clone()).into_py(py)),
-            Expr::IsFalse(expr) => Ok(PyIsFalse::new(*expr.clone()).into_py(py)),
-            Expr::IsUnknown(expr) => Ok(PyIsUnknown::new(*expr.clone()).into_py(py)),
-            Expr::IsNotTrue(expr) => Ok(PyIsNotTrue::new(*expr.clone()).into_py(py)),
-            Expr::IsNotFalse(expr) => Ok(PyIsNotFalse::new(*expr.clone()).into_py(py)),
-            Expr::IsNotUnknown(expr) => Ok(PyIsNotUnknown::new(*expr.clone()).into_py(py)),
-            Expr::Negative(expr) => Ok(PyNegative::new(*expr.clone()).into_py(py)),
+            Expr::Like(value) => Ok(PyLike::from(value.clone()).into_bound_py_any(py)?),
+            Expr::Literal(value) => Ok(PyLiteral::from(value.clone()).into_bound_py_any(py)?),
+            Expr::BinaryExpr(expr) => Ok(PyBinaryExpr::from(expr.clone()).into_bound_py_any(py)?),
+            Expr::Not(expr) => Ok(PyNot::new(*expr.clone()).into_bound_py_any(py)?),
+            Expr::IsNotNull(expr) => Ok(PyIsNotNull::new(*expr.clone()).into_bound_py_any(py)?),
+            Expr::IsNull(expr) => Ok(PyIsNull::new(*expr.clone()).into_bound_py_any(py)?),
+            Expr::IsTrue(expr) => Ok(PyIsTrue::new(*expr.clone()).into_bound_py_any(py)?),
+            Expr::IsFalse(expr) => Ok(PyIsFalse::new(*expr.clone()).into_bound_py_any(py)?),
+            Expr::IsUnknown(expr) => Ok(PyIsUnknown::new(*expr.clone()).into_bound_py_any(py)?),
+            Expr::IsNotTrue(expr) => Ok(PyIsNotTrue::new(*expr.clone()).into_bound_py_any(py)?),
+            Expr::IsNotFalse(expr) => Ok(PyIsNotFalse::new(*expr.clone()).into_bound_py_any(py)?),
+            Expr::IsNotUnknown(expr) => Ok(PyIsNotUnknown::new(*expr.clone()).into_bound_py_any(py)?),
+            Expr::Negative(expr) => Ok(PyNegative::new(*expr.clone()).into_bound_py_any(py)?),
             Expr::AggregateFunction(expr) => {
-                Ok(PyAggregateFunction::from(expr.clone()).into_py(py))
+                Ok(PyAggregateFunction::from(expr.clone()).into_bound_py_any(py)?)
             }
-            Expr::SimilarTo(value) => Ok(PySimilarTo::from(value.clone()).into_py(py)),
-            Expr::Between(value) => Ok(between::PyBetween::from(value.clone()).into_py(py)),
-            Expr::Case(value) => Ok(case::PyCase::from(value.clone()).into_py(py)),
-            Expr::Cast(value) => Ok(cast::PyCast::from(value.clone()).into_py(py)),
-            Expr::TryCast(value) => Ok(cast::PyTryCast::from(value.clone()).into_py(py)),
+            Expr::SimilarTo(value) => Ok(PySimilarTo::from(value.clone()).into_bound_py_any(py)?),
+            Expr::Between(value) => Ok(between::PyBetween::from(value.clone()).into_bound_py_any(py)?),
+            Expr::Case(value) => Ok(case::PyCase::from(value.clone()).into_bound_py_any(py)?),
+            Expr::Cast(value) => Ok(cast::PyCast::from(value.clone()).into_bound_py_any(py)?),
+            Expr::TryCast(value) => Ok(cast::PyTryCast::from(value.clone()).into_bound_py_any(py)?),
             Expr::ScalarFunction(value) => Err(py_unsupported_variant_err(format!(
                 "Converting Expr::ScalarFunction to a Python object is not implemented: {:?}",
                 value
@@ -163,29 +164,29 @@ impl PyExpr {
                 "Converting Expr::WindowFunction to a Python object is not implemented: {:?}",
                 value
             ))),
-            Expr::InList(value) => Ok(in_list::PyInList::from(value.clone()).into_py(py)),
-            Expr::Exists(value) => Ok(exists::PyExists::from(value.clone()).into_py(py)),
+            Expr::InList(value) => Ok(in_list::PyInList::from(value.clone()).into_bound_py_any(py)?),
+            Expr::Exists(value) => Ok(exists::PyExists::from(value.clone()).into_bound_py_any(py)?),
             Expr::InSubquery(value) => {
-                Ok(in_subquery::PyInSubquery::from(value.clone()).into_py(py))
+                Ok(in_subquery::PyInSubquery::from(value.clone()).into_bound_py_any(py)?)
             }
             Expr::ScalarSubquery(value) => {
-                Ok(scalar_subquery::PyScalarSubquery::from(value.clone()).into_py(py))
+                Ok(scalar_subquery::PyScalarSubquery::from(value.clone()).into_bound_py_any(py)?)
             }
             Expr::Wildcard { qualifier, options } => Err(py_unsupported_variant_err(format!(
                 "Converting Expr::Wildcard to a Python object is not implemented : {:?} {:?}",
                 qualifier, options
             ))),
             Expr::GroupingSet(value) => {
-                Ok(grouping_set::PyGroupingSet::from(value.clone()).into_py(py))
+                Ok(grouping_set::PyGroupingSet::from(value.clone()).into_bound_py_any(py)?)
             }
             Expr::Placeholder(value) => {
-                Ok(placeholder::PyPlaceholder::from(value.clone()).into_py(py))
+                Ok(placeholder::PyPlaceholder::from(value.clone()).into_bound_py_any(py)?)
             }
             Expr::OuterReferenceColumn(data_type, column) => Err(py_unsupported_variant_err(format!(
                 "Converting Expr::OuterReferenceColumn to a Python object is not implemented: {:?} - {:?}",
                 data_type, column
             ))),
-            Expr::Unnest(value) => Ok(unnest_expr::PyUnnestExpr::from(value.clone()).into_py(py)),
+            Expr::Unnest(value) => Ok(unnest_expr::PyUnnestExpr::from(value.clone()).into_bound_py_any(py)?),
         }
         })
     }

--- a/src/expr/aggregate.rs
+++ b/src/expr/aggregate.rs
@@ -19,7 +19,7 @@ use datafusion::common::DataFusionError;
 use datafusion::logical_expr::expr::{AggregateFunction, Alias};
 use datafusion::logical_expr::logical_plan::Aggregate;
 use datafusion::logical_expr::Expr;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 use std::fmt::{self, Display, Formatter};
 
 use super::logical_node::LogicalNode;
@@ -151,7 +151,7 @@ impl LogicalNode for PyAggregate {
         vec![PyLogicalPlan::from((*self.aggregate.input).clone())]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/analyze.rs
+++ b/src/expr/analyze.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use datafusion::logical_expr::logical_plan::Analyze;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 use std::fmt::{self, Display, Formatter};
 
 use super::logical_node::LogicalNode;
@@ -78,7 +78,7 @@ impl LogicalNode for PyAnalyze {
         vec![PyLogicalPlan::from((*self.analyze.input).clone())]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/create_memory_table.rs
+++ b/src/expr/create_memory_table.rs
@@ -18,7 +18,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use datafusion::logical_expr::CreateMemoryTable;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 
 use crate::sql::logical::PyLogicalPlan;
 
@@ -91,7 +91,7 @@ impl LogicalNode for PyCreateMemoryTable {
         vec![PyLogicalPlan::from((*self.create.input).clone())]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/create_view.rs
+++ b/src/expr/create_view.rs
@@ -18,7 +18,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use datafusion::logical_expr::{CreateView, DdlStatement, LogicalPlan};
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 
 use crate::{errors::py_type_err, sql::logical::PyLogicalPlan};
 
@@ -88,8 +88,8 @@ impl LogicalNode for PyCreateView {
         vec![PyLogicalPlan::from((*self.create.input).clone())]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }
 

--- a/src/expr/distinct.rs
+++ b/src/expr/distinct.rs
@@ -18,7 +18,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use datafusion::logical_expr::Distinct;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 
 use crate::sql::logical::PyLogicalPlan;
 
@@ -89,7 +89,7 @@ impl LogicalNode for PyDistinct {
         }
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/drop_table.rs
+++ b/src/expr/drop_table.rs
@@ -18,7 +18,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use datafusion::logical_expr::logical_plan::DropTable;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 
 use crate::sql::logical::PyLogicalPlan;
 
@@ -83,7 +83,7 @@ impl LogicalNode for PyDropTable {
         vec![]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/empty_relation.rs
+++ b/src/expr/empty_relation.rs
@@ -17,7 +17,7 @@
 
 use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 use datafusion::logical_expr::EmptyRelation;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 use std::fmt::{self, Display, Formatter};
 
 use super::logical_node::LogicalNode;
@@ -79,7 +79,7 @@ impl LogicalNode for PyEmptyRelation {
         vec![]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/explain.rs
+++ b/src/expr/explain.rs
@@ -18,7 +18,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use datafusion::logical_expr::{logical_plan::Explain, LogicalPlan};
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 
 use crate::{common::df_schema::PyDFSchema, errors::py_type_err, sql::logical::PyLogicalPlan};
 
@@ -104,7 +104,7 @@ impl LogicalNode for PyExplain {
         vec![]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/extension.rs
+++ b/src/expr/extension.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use datafusion::logical_expr::Extension;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 
 use crate::sql::logical::PyLogicalPlan;
 
@@ -46,7 +46,7 @@ impl LogicalNode for PyExtension {
         vec![]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/filter.rs
+++ b/src/expr/filter.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use datafusion::logical_expr::logical_plan::Filter;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 use std::fmt::{self, Display, Formatter};
 
 use crate::common::df_schema::PyDFSchema;
@@ -81,7 +81,7 @@ impl LogicalNode for PyFilter {
         vec![PyLogicalPlan::from((*self.filter.input).clone())]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/join.rs
+++ b/src/expr/join.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use datafusion::logical_expr::logical_plan::{Join, JoinConstraint, JoinType};
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 use std::fmt::{self, Display, Formatter};
 
 use crate::common::df_schema::PyDFSchema;
@@ -193,7 +193,7 @@ impl LogicalNode for PyJoin {
         ]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/limit.rs
+++ b/src/expr/limit.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use datafusion::logical_expr::logical_plan::Limit;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 use std::fmt::{self, Display, Formatter};
 
 use crate::common::df_schema::PyDFSchema;
@@ -90,7 +90,7 @@ impl LogicalNode for PyLimit {
         vec![PyLogicalPlan::from((*self.limit.input).clone())]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/literal.rs
+++ b/src/expr/literal.rs
@@ -17,7 +17,7 @@
 
 use crate::errors::PyDataFusionError;
 use datafusion::common::ScalarValue;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 
 #[pyclass(name = "Literal", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
@@ -144,8 +144,8 @@ impl PyLiteral {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    fn into_type(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn into_type<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 
     fn __repr__(&self) -> PyResult<String> {

--- a/src/expr/logical_node.rs
+++ b/src/expr/logical_node.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use pyo3::{PyObject, PyResult, Python};
+use pyo3::{Bound, PyAny, PyResult, Python};
 
 use crate::sql::logical::PyLogicalPlan;
 
@@ -25,5 +25,5 @@ pub trait LogicalNode {
     /// The input plan to the current logical node instance.
     fn inputs(&self) -> Vec<PyLogicalPlan>;
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject>;
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>>;
 }

--- a/src/expr/projection.rs
+++ b/src/expr/projection.rs
@@ -17,7 +17,7 @@
 
 use datafusion::logical_expr::logical_plan::Projection;
 use datafusion::logical_expr::Expr;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 use std::fmt::{self, Display, Formatter};
 
 use crate::common::df_schema::PyDFSchema;
@@ -113,7 +113,7 @@ impl LogicalNode for PyProjection {
         vec![PyLogicalPlan::from((*self.projection.input).clone())]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/repartition.rs
+++ b/src/expr/repartition.rs
@@ -18,7 +18,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use datafusion::logical_expr::{logical_plan::Repartition, Expr, Partitioning};
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 
 use crate::{errors::py_type_err, sql::logical::PyLogicalPlan};
 
@@ -121,7 +121,7 @@ impl LogicalNode for PyRepartition {
         vec![PyLogicalPlan::from((*self.repartition.input).clone())]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/sort.rs
+++ b/src/expr/sort.rs
@@ -17,7 +17,7 @@
 
 use datafusion::common::DataFusionError;
 use datafusion::logical_expr::logical_plan::Sort;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 use std::fmt::{self, Display, Formatter};
 
 use crate::common::df_schema::PyDFSchema;
@@ -96,7 +96,7 @@ impl LogicalNode for PySort {
         vec![PyLogicalPlan::from((*self.sort.input).clone())]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/subquery.rs
+++ b/src/expr/subquery.rs
@@ -18,7 +18,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use datafusion::logical_expr::Subquery;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 
 use crate::sql::logical::PyLogicalPlan;
 
@@ -75,7 +75,7 @@ impl LogicalNode for PySubquery {
         vec![]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/subquery_alias.rs
+++ b/src/expr/subquery_alias.rs
@@ -18,7 +18,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use datafusion::logical_expr::SubqueryAlias;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 
 use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
@@ -85,7 +85,7 @@ impl LogicalNode for PySubqueryAlias {
         vec![PyLogicalPlan::from((*self.subquery_alias.input).clone())]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/table_scan.rs
+++ b/src/expr/table_scan.rs
@@ -17,7 +17,7 @@
 
 use datafusion::common::TableReference;
 use datafusion::logical_expr::logical_plan::TableScan;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 use std::fmt::{self, Display, Formatter};
 
 use crate::expr::logical_node::LogicalNode;
@@ -146,7 +146,7 @@ impl LogicalNode for PyTableScan {
         vec![]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/union.rs
+++ b/src/expr/union.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use datafusion::logical_expr::logical_plan::Union;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 use std::fmt::{self, Display, Formatter};
 
 use crate::common::df_schema::PyDFSchema;
@@ -83,7 +83,7 @@ impl LogicalNode for PyUnion {
             .collect()
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/unnest.rs
+++ b/src/expr/unnest.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use datafusion::logical_expr::logical_plan::Unnest;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 use std::fmt::{self, Display, Formatter};
 
 use crate::common::df_schema::PyDFSchema;
@@ -79,7 +79,7 @@ impl LogicalNode for PyUnnest {
         vec![PyLogicalPlan::from((*self.unnest_.input).clone())]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/expr/window.rs
+++ b/src/expr/window.rs
@@ -18,7 +18,7 @@
 use datafusion::common::{DataFusionError, ScalarValue};
 use datafusion::logical_expr::expr::WindowFunction;
 use datafusion::logical_expr::{Expr, Window, WindowFrame, WindowFrameBound, WindowFrameUnits};
-use pyo3::prelude::*;
+use pyo3::{prelude::*, IntoPyObjectExt};
 use std::fmt::{self, Display, Formatter};
 
 use crate::common::data_type::PyScalarValue;
@@ -289,7 +289,7 @@ impl LogicalNode for PyWindowExpr {
         vec![self.window.input.as_ref().clone().into()]
     }
 
-    fn to_variant(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.clone().into_py(py))
+    fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.clone().into_bound_py_any(py)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ fn _internal(py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
 
 #[cfg(feature = "substrait")]
 fn setup_substrait_module(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    let substrait = PyModule::new_bound(py, "substrait")?;
+    let substrait = PyModule::new(py, "substrait")?;
     substrait::init_module(&substrait)?;
     m.add_submodule(&substrait)?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,21 +94,21 @@ fn _internal(py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<record_batch::PyRecordBatchStream>()?;
 
     // Register `common` as a submodule. Matching `datafusion-common` https://docs.rs/datafusion-common/latest/datafusion_common/
-    let common = PyModule::new_bound(py, "common")?;
+    let common = PyModule::new(py, "common")?;
     common::init_module(&common)?;
     m.add_submodule(&common)?;
 
     // Register `expr` as a submodule. Matching `datafusion-expr` https://docs.rs/datafusion-expr/latest/datafusion_expr/
-    let expr = PyModule::new_bound(py, "expr")?;
+    let expr = PyModule::new(py, "expr")?;
     expr::init_module(&expr)?;
     m.add_submodule(&expr)?;
 
     // Register the functions as a submodule
-    let funcs = PyModule::new_bound(py, "functions")?;
+    let funcs = PyModule::new(py, "functions")?;
     functions::init_module(&funcs)?;
     m.add_submodule(&funcs)?;
 
-    let store = PyModule::new_bound(py, "object_store")?;
+    let store = PyModule::new(py, "object_store")?;
     store::init_module(&store)?;
     m.add_submodule(&store)?;
 

--- a/src/physical_plan.rs
+++ b/src/physical_plan.rs
@@ -66,7 +66,7 @@ impl PyExecutionPlan {
         )?;
 
         let bytes = proto.encode_to_vec();
-        Ok(PyBytes::new_bound(py, &bytes))
+        Ok(PyBytes::new(py, &bytes))
     }
 
     #[staticmethod]

--- a/src/pyarrow_util.rs
+++ b/src/pyarrow_util.rs
@@ -33,8 +33,8 @@ impl FromPyArrow for PyScalarValue {
         let val = value.call_method0("as_py")?;
 
         // construct pyarrow array from the python value and pyarrow type
-        let factory = py.import_bound("pyarrow")?.getattr("array")?;
-        let args = PyList::new_bound(py, [val]);
+        let factory = py.import("pyarrow")?.getattr("array")?;
+        let args = PyList::new(py, [val])?;
         let array = factory.call1((args, typ))?;
 
         // convert the pyarrow array to rust array using C data interface

--- a/src/sql/logical.rs
+++ b/src/sql/logical.rs
@@ -64,7 +64,7 @@ impl PyLogicalPlan {
 #[pymethods]
 impl PyLogicalPlan {
     /// Return the specific logical operator
-    pub fn to_variant(&self, py: Python) -> PyResult<PyObject> {
+    pub fn to_variant<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         match self.plan.as_ref() {
             LogicalPlan::Aggregate(plan) => PyAggregate::from(plan.clone()).to_variant(py),
             LogicalPlan::Analyze(plan) => PyAnalyze::from(plan.clone()).to_variant(py),
@@ -132,7 +132,7 @@ impl PyLogicalPlan {
             datafusion_proto::protobuf::LogicalPlanNode::try_from_logical_plan(&self.plan, &codec)?;
 
         let bytes = proto.encode_to_vec();
-        Ok(PyBytes::new_bound(py, &bytes))
+        Ok(PyBytes::new(py, &bytes))
     }
 
     #[staticmethod]

--- a/src/substrait.rs
+++ b/src/substrait.rs
@@ -40,7 +40,7 @@ impl PyPlan {
         self.plan
             .encode(&mut proto_bytes)
             .map_err(PyDataFusionError::EncodeError)?;
-        Ok(PyBytes::new_bound(py, &proto_bytes).unbind().into())
+        Ok(PyBytes::new(py, &proto_bytes).into())
     }
 }
 
@@ -95,7 +95,7 @@ impl PySubstraitSerializer {
         py: Python,
     ) -> PyDataFusionResult<PyObject> {
         let proto_bytes: Vec<u8> = wait_for_future(py, serializer::serialize_bytes(sql, &ctx.ctx))?;
-        Ok(PyBytes::new_bound(py, &proto_bytes).unbind().into())
+        Ok(PyBytes::new(py, &proto_bytes).into())
     }
 
     #[staticmethod]

--- a/src/udaf.rs
+++ b/src/udaf.rs
@@ -29,6 +29,7 @@ use datafusion::logical_expr::{
 };
 
 use crate::common::data_type::PyScalarValue;
+use crate::errors::to_datafusion_err;
 use crate::expr::PyExpr;
 use crate::utils::parse_volatility;
 
@@ -73,7 +74,7 @@ impl Accumulator for RustAccumulator {
                 .iter()
                 .map(|arg| arg.into_data().to_pyarrow(py).unwrap())
                 .collect::<Vec<_>>();
-            let py_args = PyTuple::new_bound(py, py_args);
+            let py_args = PyTuple::new(py, py_args).map_err(to_datafusion_err)?;
 
             // 2. call function
             self.accum
@@ -119,7 +120,7 @@ impl Accumulator for RustAccumulator {
                 .iter()
                 .map(|arg| arg.into_data().to_pyarrow(py).unwrap())
                 .collect::<Vec<_>>();
-            let py_args = PyTuple::new_bound(py, py_args);
+            let py_args = PyTuple::new(py, py_args).map_err(to_datafusion_err)?;
 
             // 2. call function
             self.accum

--- a/src/udf.rs
+++ b/src/udf.rs
@@ -28,6 +28,7 @@ use datafusion::logical_expr::function::ScalarFunctionImplementation;
 use datafusion::logical_expr::ScalarUDF;
 use datafusion::logical_expr::{create_udf, ColumnarValue};
 
+use crate::errors::to_datafusion_err;
 use crate::expr::PyExpr;
 use crate::utils::parse_volatility;
 
@@ -46,11 +47,11 @@ fn pyarrow_function_to_rust(
                         .map_err(|e| DataFusionError::Execution(format!("{e:?}")))
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            let py_args = PyTuple::new_bound(py, py_args);
+            let py_args = PyTuple::new(py, py_args).map_err(to_datafusion_err)?;
 
             // 2. call function
             let value = func
-                .call_bound(py, py_args, None)
+                .call(py, py_args, None)
                 .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
 
             // 3. cast to arrow::array::Array

--- a/src/udwf.rs
+++ b/src/udwf.rs
@@ -27,6 +27,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use crate::common::data_type::PyScalarValue;
+use crate::errors::to_datafusion_err;
 use crate::expr::PyExpr;
 use crate::utils::parse_volatility;
 use datafusion::arrow::datatypes::DataType;
@@ -56,8 +57,8 @@ impl PartitionEvaluator for RustPartitionEvaluator {
 
     fn get_range(&self, idx: usize, n_rows: usize) -> Result<Range<usize>> {
         Python::with_gil(|py| {
-            let py_args = vec![idx.to_object(py), n_rows.to_object(py)];
-            let py_args = PyTuple::new_bound(py, py_args);
+            let py_args = vec![idx.into_pyobject(py)?, n_rows.into_pyobject(py)?];
+            let py_args = PyTuple::new(py, py_args)?;
 
             self.evaluator
                 .bind(py)
@@ -93,17 +94,17 @@ impl PartitionEvaluator for RustPartitionEvaluator {
     fn evaluate_all(&mut self, values: &[ArrayRef], num_rows: usize) -> Result<ArrayRef> {
         println!("evaluate all called with number of values {}", values.len());
         Python::with_gil(|py| {
-            let py_values = PyList::new_bound(
+            let py_values = PyList::new(
                 py,
                 values
                     .iter()
                     .map(|arg| arg.into_data().to_pyarrow(py).unwrap()),
-            );
-            let py_num_rows = num_rows.to_object(py).into_bound(py);
-            let py_args = PyTuple::new_bound(
+            )?;
+            let py_num_rows = num_rows.into_pyobject(py)?;
+            let py_args = PyTuple::new(
                 py,
-                PyTuple::new_bound(py, vec![py_values.as_any(), &py_num_rows]),
-            );
+                PyTuple::new(py, vec![py_values.as_any(), &py_num_rows])?,
+            )?;
 
             self.evaluator
                 .bind(py)
@@ -112,32 +113,34 @@ impl PartitionEvaluator for RustPartitionEvaluator {
                     let array_data = ArrayData::from_pyarrow_bound(&v).unwrap();
                     make_array(array_data)
                 })
-                .map_err(|e| DataFusionError::Execution(format!("{e}")))
         })
+        .map_err(to_datafusion_err)
     }
 
     fn evaluate(&mut self, values: &[ArrayRef], range: &Range<usize>) -> Result<ScalarValue> {
         Python::with_gil(|py| {
-            let py_values = PyList::new_bound(
+            let py_values = PyList::new(
                 py,
                 values
                     .iter()
                     .map(|arg| arg.into_data().to_pyarrow(py).unwrap()),
-            );
-            let range_tuple =
-                PyTuple::new_bound(py, vec![range.start.to_object(py), range.end.to_object(py)]);
-            let py_args = PyTuple::new_bound(
+            )?;
+            let range_tuple = PyTuple::new(
                 py,
-                PyTuple::new_bound(py, vec![py_values.as_any(), range_tuple.as_any()]),
-            );
+                vec![range.start.into_pyobject(py)?, range.end.into_pyobject(py)?],
+            )?;
+            let py_args = PyTuple::new(
+                py,
+                PyTuple::new(py, vec![py_values.as_any(), range_tuple.as_any()]),
+            )?;
 
             self.evaluator
                 .bind(py)
                 .call_method1("evaluate", py_args)
                 .and_then(|v| v.extract::<PyScalarValue>())
                 .map(|v| v.0)
-                .map_err(|e| DataFusionError::Execution(format!("{e}")))
         })
+        .map_err(to_datafusion_err)
     }
 
     fn evaluate_all_with_rank(
@@ -148,23 +151,27 @@ impl PartitionEvaluator for RustPartitionEvaluator {
         Python::with_gil(|py| {
             let ranks = ranks_in_partition
                 .iter()
-                .map(|r| PyTuple::new_bound(py, vec![r.start, r.end]));
+                .map(|r| PyTuple::new(py, vec![r.start, r.end]))
+                .collect::<PyResult<Vec<_>>>()?;
 
             // 1. cast args to Pyarrow array
-            let py_args = vec![num_rows.to_object(py), PyList::new_bound(py, ranks).into()];
+            let py_args = vec![
+                num_rows.into_pyobject(py)?.into_any(),
+                PyList::new(py, ranks)?.into_any(),
+            ];
 
-            let py_args = PyTuple::new_bound(py, py_args);
+            let py_args = PyTuple::new(py, py_args)?;
 
             // 2. call function
             self.evaluator
                 .bind(py)
                 .call_method1("evaluate_all_with_rank", py_args)
-                .map_err(|e| DataFusionError::Execution(format!("{e}")))
                 .map(|v| {
                     let array_data = ArrayData::from_pyarrow_bound(&v).unwrap();
                     make_array(array_data)
                 })
         })
+        .map_err(to_datafusion_err)
     }
 
     fn supports_bounded_execution(&self) -> bool {

--- a/src/udwf.rs
+++ b/src/udwf.rs
@@ -101,10 +101,7 @@ impl PartitionEvaluator for RustPartitionEvaluator {
                     .map(|arg| arg.into_data().to_pyarrow(py).unwrap()),
             )?;
             let py_num_rows = num_rows.into_pyobject(py)?;
-            let py_args = PyTuple::new(
-                py,
-                PyTuple::new(py, vec![py_values.as_any(), &py_num_rows])?,
-            )?;
+            let py_args = PyTuple::new(py, vec![py_values.as_any(), &py_num_rows])?;
 
             self.evaluator
                 .bind(py)
@@ -125,14 +122,8 @@ impl PartitionEvaluator for RustPartitionEvaluator {
                     .iter()
                     .map(|arg| arg.into_data().to_pyarrow(py).unwrap()),
             )?;
-            let range_tuple = PyTuple::new(
-                py,
-                vec![range.start.into_pyobject(py)?, range.end.into_pyobject(py)?],
-            )?;
-            let py_args = PyTuple::new(
-                py,
-                PyTuple::new(py, vec![py_values.as_any(), range_tuple.as_any()]),
-            )?;
+            let range_tuple = PyTuple::new(py, vec![range.start, range.end])?;
+            let py_args = PyTuple::new(py, vec![py_values.as_any(), range_tuple.as_any()])?;
 
             self.evaluator
                 .bind(py)


### PR DESCRIPTION
# Which issue does this PR close?

None, but it supports PR https://github.com/apache/datafusion-python/pull/1029

 # Rationale for this change

pyo3 update recently introduced a lot of warnings about deprecated APIs. This PR addresses those warnings.

# What changes are included in this PR?

Changed to new interfaces and associated error returns.

# Are there any user-facing changes?
None