### PR TITLE
Improve collection during repr and repr_html

### DIFF
--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
+import re
 from typing import Any
 
 import pyarrow as pa
@@ -1245,13 +1246,17 @@ def test_dataframe_transform(df):
 def test_dataframe_repr_html(df) -> None:
     output = df._repr_html_()
 
-    ref_html = """<table border='1'>
-        <tr><th>a</td><th>b</td><th>c</td></tr>
-        <tr><td>1</td><td>4</td><td>8</td></tr>
-        <tr><td>2</td><td>5</td><td>5</td></tr>
-        <tr><td>3</td><td>6</td><td>8</td></tr>
-        </table>
-        """
+    # Since we've added a fair bit of processing to the html output, lets just verify
+    # the values we are expecting in the table exist. Use regex and ignore everything
+    # between the <th></th> and <td></td>. We also don't want the closing > on the
+    # td and th segments because that is where the formatting data is written.
 
-    # Ignore whitespace just to make this test look cleaner
-    assert output.replace(" ", "") == ref_html.replace(" ", "")
+    headers = ["a", "b", "c"]
+    headers = [f"<th(.*?)>{v}</th>" for v in headers]
+    header_pattern = "(.*?)".join(headers)
+    assert len(re.findall(header_pattern, output, re.DOTALL)) == 1
+
+    body_data = [[1, 4, 8], [2, 5, 5], [3, 6, 8]]
+    body_lines = [f"<td(.*?)>{v}</td>" for inner in body_data for v in inner]
+    body_pattern = "(.*?)".join(body_lines)
+    assert len(re.findall(body_pattern, output, re.DOTALL)) == 1

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -887,7 +887,8 @@ async fn collect_record_batches_to_display(
     min_rows: usize,
     max_rows: usize,
 ) -> Result<(Vec<RecordBatch>, bool), DataFusionError> {
-    let mut stream = df.execute_stream().await?;
+    let partitioned_stream = df.execute_stream_partitioned().await?;
+    let mut stream = futures::stream::iter(partitioned_stream).flatten();
     let mut size_estimate_so_far = 0;
     let mut rows_so_far = 0;
     let mut record_batches = Vec::default();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -42,7 +42,7 @@ pub(crate) fn get_tokio_runtime() -> &'static TokioRuntime {
 #[inline]
 pub(crate) fn get_global_ctx() -> &'static SessionContext {
     static CTX: OnceLock<SessionContext> = OnceLock::new();
-    CTX.get_or_init(|| SessionContext::new())
+    CTX.get_or_init(SessionContext::new)
 }
 
 /// Utility to collect rust futures with GIL released


### PR DESCRIPTION
# Which issue does this PR close?

None.

 # Rationale for this change

The notebook rendering of DataFrames is very useful, but it can be enhanced. This PR adds quality of life improvements such as

- The table is now scrollable both vertically and horizontally
- Instead of collecting an arbitrary 10 rows, we collect up to 2 MB worth of data
- For Scalars that render to long strings (25 characters) we limit them down and have a `...` button to allow expanding the cell so you can view it in it's entirety
- When we have more data available than is displayed we indicate this to the user that the data are truncated
- When there are no data returned, we write this to the user

# What changes are included in this PR?

This PR adds a feature to collect record batches and uses their size estimate to collect up to 2MB worth of data. This is typically enough for most use cases to review the data, but it is a constant we can update. We determine how many rows to show to the user which is either 2MB worth (record batch will easily have more than this) or at least 20 rows (also up for changing). We then render this as a html table

In the rendering we see if the individual cell contains more than 25 characters. If so we show a 25 character snippet of the string representation of the data and a `...` button that has a javascript call to update which data are displayed in the cell.

# Are there any user-facing changes?

Yes, but not to the API. Any user who uses jupyter notebooks will experience these enhanced tables.

See the below screenshots for examples:
![table-views-1](https://github.com/user-attachments/assets/e7d4954f-33b4-43c5-82d9-832e31e2222c)
<img width="1022" alt="table-views-2" src="https://github.com/user-attachments/assets/3098f9a4-f5a5-4658-a3f5-dd6ba7706e4b" />
<img width="1127" alt="table-views-3" src="https://github.com/user-attachments/assets/c73a6118-75ea-4a40-9e50-2aa5718be03c" />
