### PR TITLE
feat: Implementation of udf and udaf decorator

### DIFF
--- a/python/datafusion/__init__.py
+++ b/python/datafusion/__init__.py
@@ -118,9 +118,7 @@ def lit(value):
 
 
 udf = ScalarUDF.udf
-udf_decorator = ScalarUDF.udf_decorator
 
 udaf = AggregateUDF.udaf
-udaf_decorator = AggregateUDF.udaf_decorator
 
 udwf = WindowUDF.udwf

--- a/python/datafusion/__init__.py
+++ b/python/datafusion/__init__.py
@@ -118,7 +118,9 @@ def lit(value):
 
 
 udf = ScalarUDF.udf
+udf_decorator = ScalarUDF.udf_decorator
 
 udaf = AggregateUDF.udaf
+udaf_decorator = AggregateUDF.udaf_decorator
 
 udwf = WindowUDF.udwf

--- a/python/datafusion/udf.py
+++ b/python/datafusion/udf.py
@@ -136,14 +136,14 @@ class ScalarUDF:
 
         Example:
             **Using `udf` as a function:**
-            ```python
+            ```
             def double_func(x):
                 return x * 2
             double_udf = udf(double_func, [pyarrow.int32()], pyarrow.int32(), "volatile", "double_it")
             ```
 
             **Using `udf` as a decorator:**
-            ```python
+            ```
             @udf([pyarrow.int32()], pyarrow.int32(), "volatile", "double_it")
             def double_udf(x):
                 return x * 2
@@ -322,10 +322,10 @@ class AggregateUDF:
 
         Args:
             accum: The accumulator python function. **Only needed when calling as a function. Skip this argument when using `udaf` as a decorator.**
-            input_types: The data types of the arguments to `accum.
+            input_types: The data types of the arguments to ``accum``.
             return_type: The data type of the return value.
             state_type: The data types of the intermediate accumulation.
-            volatility: See :py:class:Volatility for allowed values.
+            volatility: See :py:class:`Volatility` for allowed values.
             name: A descriptive name for the function.
 
         Returns:
@@ -333,8 +333,6 @@ class AggregateUDF:
             aggregation or window function calls.
         """
 
-
-            
         def __new__(cls, *args, **kwargs):
             if args and callable(args[0]):  
                 # Case 1: Used as a function, require the first parameter to be callable

--- a/python/datafusion/udf.py
+++ b/python/datafusion/udf.py
@@ -111,65 +111,96 @@ class ScalarUDF:
         args_raw = [arg.expr for arg in args]
         return Expr(self._udf.__call__(*args_raw))
 
-    @staticmethod
-    def udf(
-        func: Callable[..., _R],
-        input_types: list[pyarrow.DataType],
-        return_type: _R,
-        volatility: Volatility | str,
-        name: Optional[str] = None,
-    ) -> ScalarUDF:
-        """Create a new User-Defined Function.
+    class udf:
+        """Create a new User-Defined Function (UDF).
+
+        This class can be used both as a **function** and as a **decorator**.
+
+        Usage:
+            - **As a function**: Call `udf(func, input_types, return_type, volatility, name)`.
+            - **As a decorator**: Use `@udf(input_types, return_type, volatility, name)`.
+            In this case, do **not** pass `func` explicitly.
 
         Args:
-            func: A callable python function.
-            input_types: The data types of the arguments to ``func``. This list
-                must be of the same length as the number of arguments.
-            return_type: The data type of the return value from the python
-                function.
-            volatility: See ``Volatility`` for allowed values.
-            name: A descriptive name for the function.
+            func (Callable, optional): **Only needed when calling as a function.**
+                Skip this argument when using `udf` as a decorator.
+            input_types (list[pyarrow.DataType]): The data types of the arguments
+                to `func`. This list must be of the same length as the number of arguments.
+            return_type (_R): The data type of the return value from the function.
+            volatility (Volatility | str): See `Volatility` for allowed values.
+            name (Optional[str]): A descriptive name for the function.
 
         Returns:
-            A user-defined aggregate function, which can be used in either data
-                aggregation or window function calls.
-        """
-        if not callable(func):
-            raise TypeError("`func` argument must be callable")
-        if name is None:
-            if hasattr(func, "__qualname__"):
-                name = func.__qualname__.lower()
-            else:
-                name = func.__class__.__name__.lower()
-        return ScalarUDF(
-            name=name,
-            func=func,
-            input_types=input_types,
-            return_type=return_type,
-            volatility=volatility,
-        )
+            A user-defined function that can be used in SQL expressions,
+            data aggregation, or window function calls.
 
-    @staticmethod
-    def udf_decorator(
-        input_types: list[pyarrow.DataType],
-        return_type: _R,
-        volatility: Volatility | str,
-        name: Optional[str] = None
-    ):
-        def decorator(func):
-            udf_caller = ScalarUDF.udf(
-                func,
-                input_types, 
-                return_type, 
-                volatility,
-                name
+        Example:
+            **Using `udf` as a function:**
+            ```python
+            def double_func(x):
+                return x * 2
+            double_udf = udf(double_func, [pyarrow.int32()], pyarrow.int32(), "volatile", "double_it")
+            ```
+
+            **Using `udf` as a decorator:**
+            ```python
+            @udf([pyarrow.int32()], pyarrow.int32(), "volatile", "double_it")
+            def double_udf(x):
+                return x * 2
+            ```
+        """
+        def __new__(cls, *args, **kwargs):
+            if args and callable(args[0]):  
+                # Case 1: Used as a function, require the first parameter to be callable
+                return cls._function(*args, **kwargs)
+            else:
+                # Case 2: Used as a decorator with parameters
+                return cls._decorator(*args, **kwargs)
+
+        @staticmethod
+        def _function(
+            func: Callable[..., _R],
+            input_types: list[pyarrow.DataType],
+            return_type: _R,
+            volatility: Volatility | str,
+            name: Optional[str] = None,
+        ) -> ScalarUDF:
+            if not callable(func):
+                raise TypeError("`func` argument must be callable")
+            if name is None:
+                if hasattr(func, "__qualname__"):
+                    name = func.__qualname__.lower()
+                else:
+                    name = func.__class__.__name__.lower()
+            return ScalarUDF(
+                name=name,
+                func=func,
+                input_types=input_types,
+                return_type=return_type,
+                volatility=volatility,
             )
-            
-            @functools.wraps(func)
-            def wrapper(*args, **kwargs):
-                return udf_caller(*args, **kwargs)
-            return wrapper
-        return decorator
+
+        @staticmethod
+        def _decorator(
+            input_types: list[pyarrow.DataType],
+            return_type: _R,
+            volatility: Volatility | str,
+            name: Optional[str] = None
+        ):
+            def decorator(func):
+                udf_caller = ScalarUDF.udf(
+                    func,
+                    input_types, 
+                    return_type, 
+                    volatility,
+                    name
+                )
+                
+                @functools.wraps(func)
+                def wrapper(*args, **kwargs):
+                    return udf_caller(*args, **kwargs)
+                return wrapper
+            return decorator
 
 class Accumulator(metaclass=ABCMeta):
     """Defines how an :py:class:`AggregateUDF` accumulates values."""
@@ -234,25 +265,27 @@ class AggregateUDF:
         args_raw = [arg.expr for arg in args]
         return Expr(self._udaf.__call__(*args_raw))
 
-    @staticmethod
-    def udaf(
-        accum: Callable[[], Accumulator],
-        input_types: pyarrow.DataType | list[pyarrow.DataType],
-        return_type: pyarrow.DataType,
-        state_type: list[pyarrow.DataType],
-        volatility: Volatility | str,
-        name: Optional[str] = None,
-    ) -> AggregateUDF:
-        """Create a new User-Defined Aggregate Function.
+    class udaf:
+        """Create a new User-Defined Aggregate Function (UDAF).
 
-        If your :py:class:`Accumulator` can be instantiated with no arguments, you
-        can simply pass it's type as ``accum``. If you need to pass additional arguments
-        to it's constructor, you can define a lambda or a factory method. During runtime
-        the :py:class:`Accumulator` will be constructed for every instance in
-        which this UDAF is used. The following examples are all valid.
+        This class allows you to define an **aggregate function** that can be used in data
+        aggregation or window function calls. 
 
-        .. code-block:: python
+        Usage:
+            - **As a function**: Call `udaf(accum, input_types, return_type, state_type,
+                volatility, name)`.
+            - **As a decorator**: Use `@udaf(input_types, return_type, state_type,
+                volatility, name)`.
+            When using `udaf` as a decorator, **do not pass `accum` explicitly**.
 
+        **Function example:**
+        
+            If your `:py:class:Accumulator` can be instantiated with no arguments, you can
+            simply pass it's type as `accum`. If you need to pass additional arguments to
+            it's constructor, you can define a lambda or a factory method. During runtime the
+            `:py:class:Accumulator` will be constructed for every instance in which this UDAF is
+            used. The following examples are all valid.
+            ```
             import pyarrow as pa
             import pyarrow.compute as pc
 
@@ -278,61 +311,89 @@ class AggregateUDF:
             udaf1 = udaf(Summarize, pa.float64(), pa.float64(), [pa.float64()], "immutable")
             udaf2 = udaf(sum_bias_10, pa.float64(), pa.float64(), [pa.float64()], "immutable")
             udaf3 = udaf(lambda: Summarize(20.0), pa.float64(), pa.float64(), [pa.float64()], "immutable")
+            ```
+        
+        **Decorator example:**
+            ```
+            @udaf(pa.float64(), pa.float64(), [pa.float64()], "immutable")
+            def udf4() -> Summarize:
+                return Summarize(10.0)
+            ```
 
         Args:
-            accum: The accumulator python function.
-            input_types: The data types of the arguments to ``accum``.
+            accum: The accumulator python function. **Only needed when calling as a function. Skip this argument when using `udaf` as a decorator.**
+            input_types: The data types of the arguments to `accum.
             return_type: The data type of the return value.
             state_type: The data types of the intermediate accumulation.
-            volatility: See :py:class:`Volatility` for allowed values.
+            volatility: See :py:class:Volatility for allowed values.
             name: A descriptive name for the function.
 
         Returns:
             A user-defined aggregate function, which can be used in either data
             aggregation or window function calls.
-        """  # noqa W505
-        if not callable(accum):
-            raise TypeError("`func` must be callable.")
-        if not isinstance(accum.__call__(), Accumulator):
-            raise TypeError(
-                "Accumulator must implement the abstract base class Accumulator"
-            )
-        if name is None:
-            name = accum.__call__().__class__.__qualname__.lower()
-        if isinstance(input_types, pyarrow.DataType):
-            input_types = [input_types]
-        return AggregateUDF(
-            name=name,
-            accumulator=accum,
-            input_types=input_types,
-            return_type=return_type,
-            state_type=state_type,
-            volatility=volatility,
-        )
-        
-    @staticmethod
-    def udaf_decorator(
-        input_types: pyarrow.DataType | list[pyarrow.DataType],
-        return_type: pyarrow.DataType,
-        state_type: list[pyarrow.DataType],
-        volatility: Volatility | str,
-        name: Optional[str] = None
-    ):
-        def decorator(accum: Callable[[], Accumulator]):
-            udaf_caller = AggregateUDF.udaf(
-                accum,
-                input_types, 
-                return_type,
-                state_type,
-                volatility,
-                name
+        """
+
+
+            
+        def __new__(cls, *args, **kwargs):
+            if args and callable(args[0]):  
+                # Case 1: Used as a function, require the first parameter to be callable
+                return cls._function(*args, **kwargs)
+            else:
+                # Case 2: Used as a decorator with parameters
+                return cls._decorator(*args, **kwargs)
+            
+        @staticmethod
+        def _function(
+            accum: Callable[[], Accumulator],
+            input_types: pyarrow.DataType | list[pyarrow.DataType],
+            return_type: pyarrow.DataType,
+            state_type: list[pyarrow.DataType],
+            volatility: Volatility | str,
+            name: Optional[str] = None,
+        ) -> AggregateUDF:
+            if not callable(accum):
+                raise TypeError("`func` must be callable.")
+            if not isinstance(accum.__call__(), Accumulator):
+                raise TypeError(
+                    "Accumulator must implement the abstract base class Accumulator"
+                )
+            if name is None:
+                name = accum.__call__().__class__.__qualname__.lower()
+            if isinstance(input_types, pyarrow.DataType):
+                input_types = [input_types]
+            return AggregateUDF(
+                name=name,
+                accumulator=accum,
+                input_types=input_types,
+                return_type=return_type,
+                state_type=state_type,
+                volatility=volatility,
             )
             
-            @functools.wraps(accum)
-            def wrapper(*args, **kwargs):
-                return udaf_caller(*args, **kwargs)
-            return wrapper
-        return decorator
+        @staticmethod
+        def _decorator(
+            input_types: pyarrow.DataType | list[pyarrow.DataType],
+            return_type: pyarrow.DataType,
+            state_type: list[pyarrow.DataType],
+            volatility: Volatility | str,
+            name: Optional[str] = None
+        ):
+            def decorator(accum: Callable[[], Accumulator]):
+                udaf_caller = AggregateUDF.udaf(
+                    accum,
+                    input_types, 
+                    return_type,
+                    state_type,
+                    volatility,
+                    name
+                )
+                
+                @functools.wraps(accum)
+                def wrapper(*args, **kwargs):
+                    return udaf_caller(*args, **kwargs)
+                return wrapper
+            return decorator
 
 
 

--- a/python/tests/test_udaf.py
+++ b/python/tests/test_udaf.py
@@ -20,7 +20,7 @@ from typing import List
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
-from datafusion import Accumulator, column, udaf, udaf_decorator
+from datafusion import Accumulator, column, udaf
 
 
 class Summarize(Accumulator):
@@ -118,10 +118,7 @@ def test_udaf_aggregate(df):
 
 def test_udaf_decorator_aggregate(df):
     
-    @udaf_decorator(pa.float64(),
-        pa.float64(),
-        [pa.float64()],
-        "immutable")
+    @udaf(pa.float64(), pa.float64(), [pa.float64()], "immutable")
     def summarize():
         return Summarize()
 
@@ -169,7 +166,7 @@ def test_udaf_aggregate_with_arguments(df):
 def test_udaf_decorator_aggregate_with_arguments(df):
     bias = 10.0
     
-    @udaf_decorator(pa.float64(),
+    @udaf(pa.float64(),
         pa.float64(),
         [pa.float64()],
         "immutable")

--- a/python/tests/test_udaf.py
+++ b/python/tests/test_udaf.py
@@ -116,8 +116,8 @@ def test_udaf_aggregate(df):
 
     assert result.column(0) == pa.array([1.0 + 2.0 + 3.0])
 
+
 def test_udaf_decorator_aggregate(df):
-    
     @udaf(pa.float64(), pa.float64(), [pa.float64()], "immutable")
     def summarize():
         return Summarize()
@@ -165,11 +165,8 @@ def test_udaf_aggregate_with_arguments(df):
 
 def test_udaf_decorator_aggregate_with_arguments(df):
     bias = 10.0
-    
-    @udaf(pa.float64(),
-        pa.float64(),
-        [pa.float64()],
-        "immutable")
+
+    @udaf(pa.float64(), pa.float64(), [pa.float64()], "immutable")
     def summarize():
         return Summarize(bias)
 

--- a/python/tests/test_udaf.py
+++ b/python/tests/test_udaf.py
@@ -20,7 +20,7 @@ from typing import List
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
-from datafusion import Accumulator, column, udaf
+from datafusion import Accumulator, column, udaf, udaf_decorator
 
 
 class Summarize(Accumulator):
@@ -116,6 +116,29 @@ def test_udaf_aggregate(df):
 
     assert result.column(0) == pa.array([1.0 + 2.0 + 3.0])
 
+def test_udaf_decorator_aggregate(df):
+    
+    @udaf_decorator(pa.float64(),
+        pa.float64(),
+        [pa.float64()],
+        "immutable")
+    def summarize():
+        return Summarize()
+
+    df1 = df.aggregate([], [summarize(column("a"))])
+
+    # execute and collect the first (and only) batch
+    result = df1.collect()[0]
+
+    assert result.column(0) == pa.array([1.0 + 2.0 + 3.0])
+
+    df2 = df.aggregate([], [summarize(column("a"))])
+
+    # Run a second time to ensure the state is properly reset
+    result = df2.collect()[0]
+
+    assert result.column(0) == pa.array([1.0 + 2.0 + 3.0])
+
 
 def test_udaf_aggregate_with_arguments(df):
     bias = 10.0
@@ -127,6 +150,31 @@ def test_udaf_aggregate_with_arguments(df):
         [pa.float64()],
         volatility="immutable",
     )
+
+    df1 = df.aggregate([], [summarize(column("a"))])
+
+    # execute and collect the first (and only) batch
+    result = df1.collect()[0]
+
+    assert result.column(0) == pa.array([bias + 1.0 + 2.0 + 3.0])
+
+    df2 = df.aggregate([], [summarize(column("a"))])
+
+    # Run a second time to ensure the state is properly reset
+    result = df2.collect()[0]
+
+    assert result.column(0) == pa.array([bias + 1.0 + 2.0 + 3.0])
+
+
+def test_udaf_decorator_aggregate_with_arguments(df):
+    bias = 10.0
+    
+    @udaf_decorator(pa.float64(),
+        pa.float64(),
+        [pa.float64()],
+        "immutable")
+    def summarize():
+        return Summarize(bias)
 
     df1 = df.aggregate([], [summarize(column("a"))])
 

--- a/python/tests/test_udf.py
+++ b/python/tests/test_udf.py
@@ -17,14 +17,14 @@
 
 import pyarrow as pa
 import pytest
-from datafusion import column, udf
+from datafusion import column, udf, udf_decorator
 
 
 @pytest.fixture
 def df(ctx):
     # create a RecordBatch and a new DataFrame from it
     batch = pa.RecordBatch.from_arrays(
-        [pa.array([1, 2, 3]), pa.array([4, 4, 6])],
+        [pa.array([1, 2, 3]), pa.array([4, 4, None])],
         names=["a", "b"],
     )
     return ctx.create_dataframe([[batch]], name="test_table")
@@ -39,10 +39,20 @@ def test_udf(df):
         volatility="immutable",
     )
 
-    df = df.select(is_null(column("a")))
+    df = df.select(is_null(column("b")))
     result = df.collect()[0].column(0)
 
-    assert result == pa.array([False, False, False])
+    assert result == pa.array([False, False, True])
+
+
+def test_udf_decorator(df):
+    @udf_decorator([pa.int64()], pa.bool_(), "immutable")
+    def is_null(x: pa.Array) -> pa.Array:
+        return x.is_null()
+
+    df = df.select(is_null(column("b")))
+    result = df.collect()[0].column(0)
+    assert result == pa.array([False, False, True])
 
 
 def test_register_udf(ctx, df) -> None:
@@ -56,10 +66,10 @@ def test_register_udf(ctx, df) -> None:
 
     ctx.register_udf(is_null)
 
-    df_result = ctx.sql("select is_null(a) from test_table")
+    df_result = ctx.sql("select is_null(b) from test_table")
     result = df_result.collect()[0].column(0)
 
-    assert result == pa.array([False, False, False])
+    assert result == pa.array([False, False, True])
 
 
 class OverThresholdUDF:
@@ -89,6 +99,26 @@ def test_udf_with_parameters(df) -> None:
         pa.bool_(),
         volatility="immutable",
     )
+
+    df2 = df.select(udf_with_param(column("a")))
+    result = df2.collect()[0].column(0)
+
+    assert result == pa.array([False, True, True])
+
+
+def test_udf_with_parameters(df) -> None:
+    @udf_decorator([pa.int64()], pa.bool_(), "immutable")
+    def udf_no_param(values: pa.Array) -> pa.Array:
+        return OverThresholdUDF()(values)
+
+    df1 = df.select(udf_no_param(column("a")))
+    result = df1.collect()[0].column(0)
+
+    assert result == pa.array([True, True, True])
+
+    @udf_decorator([pa.int64()], pa.bool_(), "immutable")
+    def udf_with_param(values: pa.Array) -> pa.Array:
+        return OverThresholdUDF(2)(values)
 
     df2 = df.select(udf_with_param(column("a")))
     result = df2.collect()[0].column(0)

--- a/python/tests/test_udf.py
+++ b/python/tests/test_udf.py
@@ -80,7 +80,7 @@ class OverThresholdUDF:
         return pa.array(v.as_py() >= self.threshold for v in values)
 
 
-def test_udf_with_parameters(df) -> None:
+def test_udf_with_parameters_function(df) -> None:
     udf_no_param = udf(
         OverThresholdUDF(),
         pa.int64(),
@@ -106,7 +106,7 @@ def test_udf_with_parameters(df) -> None:
     assert result == pa.array([False, True, True])
 
 
-def test_udf_with_parameters(df) -> None:
+def test_udf_with_parameters_decorator(df) -> None:
     @udf([pa.int64()], pa.bool_(), "immutable")
     def udf_no_param(values: pa.Array) -> pa.Array:
         return OverThresholdUDF()(values)

--- a/python/tests/test_udf.py
+++ b/python/tests/test_udf.py
@@ -17,7 +17,7 @@
 
 import pyarrow as pa
 import pytest
-from datafusion import column, udf, udf_decorator
+from datafusion import column, udf
 
 
 @pytest.fixture
@@ -46,7 +46,7 @@ def test_udf(df):
 
 
 def test_udf_decorator(df):
-    @udf_decorator([pa.int64()], pa.bool_(), "immutable")
+    @udf([pa.int64()], pa.bool_(), "immutable")
     def is_null(x: pa.Array) -> pa.Array:
         return x.is_null()
 
@@ -107,7 +107,7 @@ def test_udf_with_parameters(df) -> None:
 
 
 def test_udf_with_parameters(df) -> None:
-    @udf_decorator([pa.int64()], pa.bool_(), "immutable")
+    @udf([pa.int64()], pa.bool_(), "immutable")
     def udf_no_param(values: pa.Array) -> pa.Array:
         return OverThresholdUDF()(values)
 
@@ -116,7 +116,7 @@ def test_udf_with_parameters(df) -> None:
 
     assert result == pa.array([True, True, True])
 
-    @udf_decorator([pa.int64()], pa.bool_(), "immutable")
+    @udf([pa.int64()], pa.bool_(), "immutable")
     def udf_with_param(values: pa.Array) -> pa.Array:
         return OverThresholdUDF(2)(values)
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #806

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This PR implements decorators for `udf` and `udaf` to make UDF creation more easily.

Idea was suggested by: https://github.com/apache/datafusion-site/pull/17#discussion_r1714218915

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Implemented two decorator methods and exposed them to the users. The internal logic is simple because it serves as a wrapper to the actual `udf/udaf` methods.
- Added test cases to validate that the decorator methods are equivalent to the original APIs.
- Slight modification in `tests/test_udf.py` to make the `is_null` test cases more reliable. Previously, since all data are not null, the return value is always `[False, False, False]`, which is the same as the default empty vector. It caused confusion during my development because it didn't fail when I had a wrong implementation. I changed one value to NULL so that the output becomes `[False, False, True]`, and it can test the functionality better.
- In order to use `udf` to represent both a function and a decorator, we check if the first argument is a `Callable`. If so, then it's a function all. If not, then it is a decorator call.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, this PR provides a more straightforward way for users to create UDF and UDAF.

Old way to create UDF:
```.py
def is_of_interest_impl(
    partkey_arr: pa.Array,
    suppkey_arr: pa.Array,
    returnflag_arr: pa.Array,
) -> pa.Array:
    # Implementation skipped

is_of_interest = udf(
    is_of_interest_impl,
    [pa.int64(), pa.int64(), pa.utf8()],
    pa.bool_(),
    "stable",
)

df_udf_filter = df_lineitem.filter(
    is_of_interest(col("l_partkey"), col("l_suppkey"), col("l_returnflag"))
)
```

New way to create UDF:
```.py
@udf(
    [pa.int64(), pa.int64(), pa.utf8()],
    pa.bool_(),
    "stable")
def is_of_interest(
    partkey_arr: pa.Array,
    suppkey_arr: pa.Array,
    returnflag_arr: pa.Array,
) -> pa.Array:
    # Implementation skipped

df_udf_filter = df_lineitem.filter(
    is_of_interest(col("l_partkey"), col("l_suppkey"), col("l_returnflag"))
)
```

Old way to create UDAF:
```.py
def sum_bias_10_impl() -> Summarize:
    return Summarize(10.0)

sum_bias_10 = udaf(sum_bias_10_impl, pa.float64(), pa.float64(), [pa.float64()], "immutable")
sum_bias_10(...)
```

New way to create UDAF:
```.py
@udaf(pa.float64(), pa.float64(), [pa.float64()], "immutable")
def sum_bias_10() -> Summarize:
    return Summarize(10.0)

sum_bias_10(...)
```

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->