### PR TITLE
Add ruff check for missing futures import

### DIFF
--- a/examples/python-udwf.py
+++ b/examples/python-udwf.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from __future__ import annotations
+
 import datafusion
 import pyarrow as pa
 from datafusion import col, lit, udwf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ features = ["substrait"]
 
 # Enable docstring linting using the google style guide
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "D", "W", "I"]
+select = ["E4", "E7", "E9", "F", "FA", "D", "W", "I"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/python/datafusion/io.py
+++ b/python/datafusion/io.py
@@ -17,6 +17,8 @@
 
 """IO read functions using global context."""
 
+from __future__ import annotations
+
 import pathlib
 
 import pyarrow

--- a/python/tests/test_udaf.py
+++ b/python/tests/test_udaf.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from __future__ import annotations
+
 from typing import List
 
 import pyarrow as pa

--- a/python/tests/test_udwf.py
+++ b/python/tests/test_udwf.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from __future__ import annotations
+
 import pyarrow as pa
 import pytest
 from datafusion import SessionContext, column, lit, udwf


### PR DESCRIPTION
# Which issue does this PR close?

None

 # Rationale for this change

During testing a user discovered a missing futures import that broke importing datafusion.

# What changes are included in this PR?

- Enable ruff lint for futures
- Fix offending files

# Are there any user-facing changes?

None