### PR TITLE
feat: expose regex_count function

### DIFF
--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -217,6 +217,7 @@ __all__ = [
     "random",
     "range",
     "rank",
+    "regexp_count",
     "regexp_like",
     "regexp_match",
     "regexp_replace",
@@ -777,6 +778,23 @@ def regexp_replace(
     if flags is not None:
         flags = flags.expr
     return Expr(f.regexp_replace(string.expr, pattern.expr, replacement.expr, flags))
+
+
+def regexp_count(
+    string: Expr, pattern: Expr, start: Expr, flags: Expr | None = None
+) -> Expr:
+    """Returns the number of matches in a string.
+
+    Optional start position (the first position is 1) to search for the regular
+    expression.
+    """
+    if flags is not None:
+        flags = flags.expr
+    if start is not None:
+        start = start.expr
+    else:
+        start = Expr.expr
+    return Expr(f.regexp_count(string.expr, pattern.expr, start, flags))
 
 
 def repeat(string: Expr, n: Expr) -> Expr:

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -740,6 +740,10 @@ def test_array_function_obj_tests(stmt, py_expr):
             f.regexp_replace(column("a"), literal("(ell|orl)"), literal("-")),
             pa.array(["H-o", "W-d", "!"]),
         ),
+        (
+            f.regexp_count(column("a"), literal("(ell|orl)"), literal(1)),
+            pa.array([1, 1, 0], type=pa.int64()),
+        ),
     ],
 )
 def test_string_functions(df, function, expected_result):

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -176,7 +176,7 @@ fn regexp_replace(
 
 #[pyfunction]
 #[pyo3(signature = (string, pattern, start, flags=None))]
-/// Replaces substring(s) matching a POSIX regular expression.
+/// Returns the number of matches found in the string.
 fn regexp_count(
     string: PyExpr,
     pattern: PyExpr,

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -173,6 +173,25 @@ fn regexp_replace(
     )
     .into())
 }
+
+#[pyfunction]
+#[pyo3(signature = (string, pattern, start, flags=None))]
+/// Replaces substring(s) matching a POSIX regular expression.
+fn regexp_count(
+    string: PyExpr,
+    pattern: PyExpr,
+    start: Option<PyExpr>,
+    flags: Option<PyExpr>,
+) -> PyResult<PyExpr> {
+    Ok(functions::expr_fn::regexp_count(
+        string.expr,
+        pattern.expr,
+        start.map(|x| x.expr),
+        flags.map(|x| x.expr),
+    )
+    .into())
+}
+
 /// Creates a new Sort Expr
 #[pyfunction]
 fn order_by(expr: PyExpr, asc: bool, nulls_first: bool) -> PyResult<PySortExpr> {
@@ -943,6 +962,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(power))?;
     m.add_wrapped(wrap_pyfunction!(radians))?;
     m.add_wrapped(wrap_pyfunction!(random))?;
+    m.add_wrapped(wrap_pyfunction!(regexp_count))?;
     m.add_wrapped(wrap_pyfunction!(regexp_like))?;
     m.add_wrapped(wrap_pyfunction!(regexp_match))?;
     m.add_wrapped(wrap_pyfunction!(regexp_replace))?;


### PR DESCRIPTION
# Which issue does this PR close?

Closes (https://github.com/apache/datafusion-python/issues/803) partially


 # Rationale for this change
Expose additional regex functions to the python wrapper of datafusion

# What changes are included in this PR?
It exposes the regex-count function in datafusion to datafusion-python

# Are there any user-facing changes?
Python users will now be able to use the regex-count method on their dataframes
