### PR TITLE
1075/enhancement/Make col class with __getattr__

### DIFF
--- a/python/datafusion/__init__.py
+++ b/python/datafusion/__init__.py
@@ -26,6 +26,8 @@ try:
 except ImportError:
     import importlib_metadata
 
+from datafusion.col import col, column
+
 from . import functions, object_store, substrait
 
 # The following imports are okay to remain as opaque to the user.
@@ -90,16 +92,6 @@ __all__ = [
     "udf",
     "udwf",
 ]
-
-
-def column(value: str) -> Expr:
-    """Create a column expression."""
-    return Expr.column(value)
-
-
-def col(value: str) -> Expr:
-    """Create a column expression."""
-    return Expr.column(value)
 
 
 def literal(value) -> Expr:

--- a/python/datafusion/col.py
+++ b/python/datafusion/col.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Col class."""
+
+from datafusion.expr import Expr
+
+
+class Col:
+    """Create a column expression.
+
+    This helper class allows an extra syntax of creating columns using the __getattr__
+    method.
+    """
+
+    def __call__(self, value: str) -> Expr:
+        """Create a column expression."""
+        return Expr.column(value)
+
+    def __getattr__(self, value: str) -> Expr:
+        """Create a column using attribute syntax."""
+        # For autocomplete to work with IPython
+        if value.startswith("__wrapped__"):
+            return getattr(type(self), value)
+
+        return Expr.column(value)
+
+
+col: Col = Col()
+column: Col = Col()
+__all__ = ["col", "column"]

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -247,3 +247,26 @@ def test_fill_null(df):
     assert result.column(0) == pa.array([1, 2, 100])
     assert result.column(1) == pa.array([4, 25, 6])
     assert result.column(2) == pa.array([1234, 1234, 8])
+
+
+def test_col_getattr():
+    ctx = SessionContext()
+    data = {
+        "array_values": [[1, 2, 3], [4, 5], [6], []],
+        "struct_values": [
+            {"name": "Alice", "age": 15},
+            {"name": "Bob", "age": 14},
+            {"name": "Charlie", "age": 13},
+            {"name": None, "age": 12},
+        ],
+    }
+    df = ctx.from_pydict(data, name="table1")
+
+    names = df.select(col.struct_values["name"].alias("name")).collect()
+    names = [r.as_py() for rs in names for r in rs["name"]]
+
+    array_values = df.select(col.array_values[1].alias("value")).collect()
+    array_values = [r.as_py() for rs in array_values for r in rs["value"]]
+
+    assert names == ["Alice", "Bob", "Charlie", None]
+    assert array_values == [2, 5, None, None]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1075 

 # Rationale for this change
To improve ergonomics of the API by providing a quicker way of accessing columns using the `__getattr__` method of classes. Using the `__call__` method, the original behavior is maintained, this is only additive.
Now this is possible

```python
from datafusion import col as c

my_a_column=c.a
my_banana_column=c.banana
```

# What changes are included in this PR?

A new col.py file with the class. I removed the col and column function from `__init__` and imported col and column from col.py. I added a test that duplicates another test but uses the new syntax.

# Are there any user-facing changes?
Only optional ones as mentioned above.

No breaking changes.