### PR TITLE
ci: require approving review

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,6 +29,10 @@ github:
     rebase: false
   features:
     issues: true
+  protected_branches:
+    main:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
 
 staging:
   whoami: asf-staging


### PR DESCRIPTION
This is a change to the `.asf.yaml` file that requires an approving review to merge to `main`. I copied the configuration from our upstream `datafusion` repository.