### PR TITLE
minor: reduce error size

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -28,7 +28,7 @@ pub type PyDataFusionResult<T> = std::result::Result<T, PyDataFusionError>;
 
 #[derive(Debug)]
 pub enum PyDataFusionError {
-    ExecutionError(InnerDataFusionError),
+    ExecutionError(Box<InnerDataFusionError>),
     ArrowError(ArrowError),
     Common(String),
     PythonError(PyErr),
@@ -55,7 +55,7 @@ impl From<ArrowError> for PyDataFusionError {
 
 impl From<InnerDataFusionError> for PyDataFusionError {
     fn from(err: InnerDataFusionError) -> PyDataFusionError {
-        PyDataFusionError::ExecutionError(err)
+        PyDataFusionError::ExecutionError(Box::new(err))
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -37,9 +37,7 @@ use datafusion::logical_expr::{
 };
 
 use crate::common::data_type::{DataTypeMap, NullTreatment, PyScalarValue, RexType};
-use crate::errors::{
-    py_runtime_err, py_type_err, py_unsupported_variant_err, PyDataFusionError, PyDataFusionResult,
-};
+use crate::errors::{py_runtime_err, py_type_err, py_unsupported_variant_err, PyDataFusionResult};
 use crate::expr::aggregate_expr::PyAggregateFunction;
 use crate::expr::binary_expr::PyBinaryExpr;
 use crate::expr::column::PyColumn;
@@ -622,11 +620,11 @@ impl PyExpr {
                 order_by,
                 null_treatment,
             ),
-            _ => Err(
-                PyDataFusionError::ExecutionError(datafusion::error::DataFusionError::Plan(
-                    format!("Using {} with `over` is not allowed. Must use an aggregate or window function.", self.expr.variant_name()),
-                ))
-            ),
+            _ => Err(datafusion::error::DataFusionError::Plan(format!(
+                "Using {} with `over` is not allowed. Must use an aggregate or window function.",
+                self.expr.variant_name()
+            ))
+            .into()),
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

None. Fixes CI.

 # Rationale for this change

With the update to rustc 1.87 CI is now broken due to the error size of `DataFusionError`. This boxes that type to reduce the error type size.

# What changes are included in this PR?

Minor. Box the DataFusionError.

# Are there any user-facing changes?

None.