### PR TITLE
Add a documentation build step in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,6 +80,13 @@ jobs:
         with:
             enable-cache: true
 
+      - name: Check documentation
+        if: ${{ matrix.python-version == '3.10' && matrix.toolchain == 'stable' }}
+        run: |
+          uv sync --dev --group docs --no-install-package datafusion
+          uv run --no-project maturin develop --uv
+          uv run --no-project docs/build.sh
+
       - name: Run tests
         env:
           RUST_BACKTRACE: 1


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1138.

 # Rationale for this change
CI should fail early if documentation generation fails.

# What changes are included in this PR?
Add a step in test CI to generate documentation, and the script comes from `README.md`.

# Are there any user-facing changes?
No.