### PR TITLE
Support types other than String and Int for partition columns

### DIFF
--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -535,7 +535,7 @@ class SessionContext:
         self,
         name: str,
         path: str | pathlib.Path,
-        table_partition_cols: list[tuple[str, str]] | None = None,
+        table_partition_cols: list[tuple[str, pa.DataType]] | None = None,
         file_extension: str = ".parquet",
         schema: pa.Schema | None = None,
         file_sort_order: list[list[Expr | SortExpr]] | None = None,
@@ -774,7 +774,7 @@ class SessionContext:
         self,
         name: str,
         path: str | pathlib.Path,
-        table_partition_cols: list[tuple[str, str]] | None = None,
+        table_partition_cols: list[tuple[str, pa.DataType]] | None = None,
         parquet_pruning: bool = True,
         file_extension: str = ".parquet",
         skip_metadata: bool = True,
@@ -865,7 +865,7 @@ class SessionContext:
         schema: pa.Schema | None = None,
         schema_infer_max_records: int = 1000,
         file_extension: str = ".json",
-        table_partition_cols: list[tuple[str, str]] | None = None,
+        table_partition_cols: list[tuple[str, pa.DataType]] | None = None,
         file_compression_type: str | None = None,
     ) -> None:
         """Register a JSON file as a table.
@@ -902,7 +902,7 @@ class SessionContext:
         path: str | pathlib.Path,
         schema: pa.Schema | None = None,
         file_extension: str = ".avro",
-        table_partition_cols: list[tuple[str, str]] | None = None,
+        table_partition_cols: list[tuple[str, pa.DataType]] | None = None,
     ) -> None:
         """Register an Avro file as a table.
 
@@ -977,7 +977,7 @@ class SessionContext:
         schema: pa.Schema | None = None,
         schema_infer_max_records: int = 1000,
         file_extension: str = ".json",
-        table_partition_cols: list[tuple[str, str]] | None = None,
+        table_partition_cols: list[tuple[str, pa.DataType]] | None = None,
         file_compression_type: str | None = None,
     ) -> DataFrame:
         """Read a line-delimited JSON data source.
@@ -1016,7 +1016,7 @@ class SessionContext:
         delimiter: str = ",",
         schema_infer_max_records: int = 1000,
         file_extension: str = ".csv",
-        table_partition_cols: list[tuple[str, str]] | None = None,
+        table_partition_cols: list[tuple[str, pa.DataType]] | None = None,
         file_compression_type: str | None = None,
     ) -> DataFrame:
         """Read a CSV data source.
@@ -1060,7 +1060,7 @@ class SessionContext:
     def read_parquet(
         self,
         path: str | pathlib.Path,
-        table_partition_cols: list[tuple[str, str]] | None = None,
+        table_partition_cols: list[tuple[str, pa.DataType]] | None = None,
         parquet_pruning: bool = True,
         file_extension: str = ".parquet",
         skip_metadata: bool = True,

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -45,7 +45,6 @@ if TYPE_CHECKING:
 
     import pandas as pd
     import polars as pl
-    import pyarrow as pa
 
     from datafusion.plan import ExecutionPlan, LogicalPlan
 
@@ -1169,17 +1168,23 @@ class SessionContext:
                 elif data_type == "int":
                     converted_data_type = pa.int32()
                 else:
-                    raise ValueError(
-                        f"Unsupported literal data type '{data_type}' for partition column. Supported types are 'string' and 'int'"
+                    message = (
+                        f"Unsupported literal data type '{data_type}' for partition "
+                        "column. Supported types are 'string' and 'int'"
                     )
+                    raise ValueError(message)
             else:
                 converted_data_type = data_type
 
             converted_table_partition_cols.append((col, converted_data_type))
 
         if warn:
+            message = (
+                "using literals for table_partition_cols data types is deprecated,"
+                "use pyarrow types instead"
+            )
             warnings.warn(
-                "using literals for table_partition_cols data types is deprecated, use pyarrow types instead",
+                message,
                 category=DeprecationWarning,
                 stacklevel=2,
             )

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -1120,7 +1120,7 @@ class SessionContext:
         self,
         path: str | pathlib.Path,
         schema: pa.Schema | None = None,
-        file_partition_cols: list[tuple[str, str]] | None = None,
+        file_partition_cols: list[tuple[str, str | pa.DataType]] | None = None,
         file_extension: str = ".avro",
     ) -> DataFrame:
         """Create a :py:class:`DataFrame` for reading Avro data source.
@@ -1136,6 +1136,7 @@ class SessionContext:
         """
         if file_partition_cols is None:
             file_partition_cols = []
+        file_partition_cols = self._convert_table_partition_cols(file_partition_cols)
         return DataFrame(
             self.ctx.read_avro(str(path), schema, file_partition_cols, file_extension)
         )

--- a/python/datafusion/io.py
+++ b/python/datafusion/io.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 def read_parquet(
     path: str | pathlib.Path,
-    table_partition_cols: list[tuple[str, pa.DataType]] | None = None,
+    table_partition_cols: list[tuple[str, str | pa.DataType]] | None = None,
     parquet_pruning: bool = True,
     file_extension: str = ".parquet",
     skip_metadata: bool = True,
@@ -83,7 +83,7 @@ def read_json(
     schema: pa.Schema | None = None,
     schema_infer_max_records: int = 1000,
     file_extension: str = ".json",
-    table_partition_cols: list[tuple[str, pa.DataType]] | None = None,
+    table_partition_cols: list[tuple[str, str | pa.DataType]] | None = None,
     file_compression_type: str | None = None,
 ) -> DataFrame:
     """Read a line-delimited JSON data source.
@@ -124,7 +124,7 @@ def read_csv(
     delimiter: str = ",",
     schema_infer_max_records: int = 1000,
     file_extension: str = ".csv",
-    table_partition_cols: list[tuple[str, pa.DataType]] | None = None,
+    table_partition_cols: list[tuple[str, str | pa.DataType]] | None = None,
     file_compression_type: str | None = None,
 ) -> DataFrame:
     """Read a CSV data source.
@@ -171,7 +171,7 @@ def read_csv(
 def read_avro(
     path: str | pathlib.Path,
     schema: pa.Schema | None = None,
-    file_partition_cols: list[tuple[str, str]] | None = None,
+    file_partition_cols: list[tuple[str, str | pa.DataType]] | None = None,
     file_extension: str = ".avro",
 ) -> DataFrame:
     """Create a :py:class:`DataFrame` for reading Avro data source.

--- a/python/datafusion/io.py
+++ b/python/datafusion/io.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 def read_parquet(
     path: str | pathlib.Path,
-    table_partition_cols: list[tuple[str, str]] | None = None,
+    table_partition_cols: list[tuple[str, pa.DataType]] | None = None,
     parquet_pruning: bool = True,
     file_extension: str = ".parquet",
     skip_metadata: bool = True,
@@ -83,7 +83,7 @@ def read_json(
     schema: pa.Schema | None = None,
     schema_infer_max_records: int = 1000,
     file_extension: str = ".json",
-    table_partition_cols: list[tuple[str, str]] | None = None,
+    table_partition_cols: list[tuple[str, pa.DataType]] | None = None,
     file_compression_type: str | None = None,
 ) -> DataFrame:
     """Read a line-delimited JSON data source.
@@ -124,7 +124,7 @@ def read_csv(
     delimiter: str = ",",
     schema_infer_max_records: int = 1000,
     file_extension: str = ".csv",
-    table_partition_cols: list[tuple[str, str]] | None = None,
+    table_partition_cols: list[tuple[str, pa.DataType]] | None = None,
     file_compression_type: str | None = None,
 ) -> DataFrame:
     """Read a CSV data source.

--- a/python/tests/test_sql.py
+++ b/python/tests/test_sql.py
@@ -157,8 +157,8 @@ def test_register_parquet(ctx, tmp_path):
     assert result.to_pydict() == {"cnt": [100]}
 
 
-@pytest.mark.parametrize("path_to_str", [True, False])
-def test_register_parquet_partitioned(ctx, tmp_path, path_to_str):
+@pytest.mark.parametrize("path_to_str,legacy_data_type", [(True, False), (False, False), (False, True)] )
+def test_register_parquet_partitioned(ctx, tmp_path, path_to_str, legacy_data_type):
     dir_root = tmp_path / "dataset_parquet_partitioned"
     dir_root.mkdir(exist_ok=False)
     (dir_root / "grp=a").mkdir(exist_ok=False)
@@ -177,10 +177,12 @@ def test_register_parquet_partitioned(ctx, tmp_path, path_to_str):
 
     dir_root = str(dir_root) if path_to_str else dir_root
 
+    partition_data_type = 'string' if legacy_data_type else pa.string()
+
     ctx.register_parquet(
         "datapp",
         dir_root,
-        table_partition_cols=[("grp", pa.string())],
+        table_partition_cols=[("grp", partition_data_type)],
         parquet_pruning=True,
         file_extension=".parquet",
     )

--- a/python/tests/test_sql.py
+++ b/python/tests/test_sql.py
@@ -157,7 +157,9 @@ def test_register_parquet(ctx, tmp_path):
     assert result.to_pydict() == {"cnt": [100]}
 
 
-@pytest.mark.parametrize("path_to_str,legacy_data_type", [(True, False), (False, False), (False, True)] )
+@pytest.mark.parametrize(
+    ("path_to_str", "legacy_data_type"), [(True, False), (False, False), (False, True)]
+)
 def test_register_parquet_partitioned(ctx, tmp_path, path_to_str, legacy_data_type):
     dir_root = tmp_path / "dataset_parquet_partitioned"
     dir_root.mkdir(exist_ok=False)
@@ -177,7 +179,7 @@ def test_register_parquet_partitioned(ctx, tmp_path, path_to_str, legacy_data_ty
 
     dir_root = str(dir_root) if path_to_str else dir_root
 
-    partition_data_type = 'string' if legacy_data_type else pa.string()
+    partition_data_type = "string" if legacy_data_type else pa.string()
 
     ctx.register_parquet(
         "datapp",

--- a/python/tests/test_sql.py
+++ b/python/tests/test_sql.py
@@ -180,7 +180,7 @@ def test_register_parquet_partitioned(ctx, tmp_path, path_to_str):
     ctx.register_parquet(
         "datapp",
         dir_root,
-        table_partition_cols=[("grp", "string")],
+        table_partition_cols=[("grp", pa.string())],
         parquet_pruning=True,
         file_extension=".parquet",
     )
@@ -488,9 +488,9 @@ def test_register_listing_table(
 ):
     dir_root = tmp_path / "dataset_parquet_partitioned"
     dir_root.mkdir(exist_ok=False)
-    (dir_root / "grp=a/date_id=20201005").mkdir(exist_ok=False, parents=True)
-    (dir_root / "grp=a/date_id=20211005").mkdir(exist_ok=False, parents=True)
-    (dir_root / "grp=b/date_id=20201005").mkdir(exist_ok=False, parents=True)
+    (dir_root / "grp=a/date=2020-10-05").mkdir(exist_ok=False, parents=True)
+    (dir_root / "grp=a/date=2021-10-05").mkdir(exist_ok=False, parents=True)
+    (dir_root / "grp=b/date=2020-10-05").mkdir(exist_ok=False, parents=True)
 
     table = pa.Table.from_arrays(
         [
@@ -501,13 +501,13 @@ def test_register_listing_table(
         names=["int", "str", "float"],
     )
     pa.parquet.write_table(
-        table.slice(0, 3), dir_root / "grp=a/date_id=20201005/file.parquet"
+        table.slice(0, 3), dir_root / "grp=a/date=2020-10-05/file.parquet"
     )
     pa.parquet.write_table(
-        table.slice(3, 2), dir_root / "grp=a/date_id=20211005/file.parquet"
+        table.slice(3, 2), dir_root / "grp=a/date=2021-10-05/file.parquet"
     )
     pa.parquet.write_table(
-        table.slice(5, 10), dir_root / "grp=b/date_id=20201005/file.parquet"
+        table.slice(5, 10), dir_root / "grp=b/date=2020-10-05/file.parquet"
     )
 
     dir_root = f"file://{dir_root}/" if path_to_str else dir_root
@@ -515,7 +515,7 @@ def test_register_listing_table(
     ctx.register_listing_table(
         "my_table",
         dir_root,
-        table_partition_cols=[("grp", "string"), ("date_id", "int")],
+        table_partition_cols=[("grp", pa.string()), ("date", pa.date64())],
         file_extension=".parquet",
         schema=table.schema if pass_schema else None,
         file_sort_order=file_sort_order,
@@ -531,7 +531,7 @@ def test_register_listing_table(
     assert dict(zip(rd["grp"], rd["count"])) == {"a": 5, "b": 2}
 
     result = ctx.sql(
-        "SELECT grp, COUNT(*) AS count FROM my_table WHERE date_id=20201005 GROUP BY grp"  # noqa: E501
+        "SELECT grp, COUNT(*) AS count FROM my_table WHERE date='2020-10-05' GROUP BY grp"  # noqa: E501
     ).collect()
     result = pa.Table.from_batches(result)
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -365,7 +365,7 @@ impl PySessionContext {
                 table_partition_cols
                     .into_iter()
                     .map(|(name, ty)| (name, ty.0))
-                    .collect::<Vec<(String, DataType)>>()
+                    .collect::<Vec<(String, DataType)>>(),
             )
             .with_file_sort_order(
                 file_sort_order
@@ -647,7 +647,7 @@ impl PySessionContext {
                 table_partition_cols
                     .into_iter()
                     .map(|(name, ty)| (name, ty.0))
-                    .collect::<Vec<(String, DataType)>>()
+                    .collect::<Vec<(String, DataType)>>(),
             )
             .parquet_pruning(parquet_pruning)
             .skip_metadata(skip_metadata);
@@ -742,7 +742,7 @@ impl PySessionContext {
                 table_partition_cols
                     .into_iter()
                     .map(|(name, ty)| (name, ty.0))
-                    .collect::<Vec<(String, DataType)>>()
+                    .collect::<Vec<(String, DataType)>>(),
             );
         options.schema_infer_max_records = schema_infer_max_records;
         options.file_extension = file_extension;
@@ -773,13 +773,12 @@ impl PySessionContext {
             .to_str()
             .ok_or_else(|| PyValueError::new_err("Unable to convert path to a string"))?;
 
-        let mut options = AvroReadOptions::default()
-            .table_partition_cols(
-                table_partition_cols
-                    .into_iter()
-                    .map(|(name, ty)| (name, ty.0))
-                    .collect::<Vec<(String, DataType)>>()
-            );
+        let mut options = AvroReadOptions::default().table_partition_cols(
+            table_partition_cols
+                .into_iter()
+                .map(|(name, ty)| (name, ty.0))
+                .collect::<Vec<(String, DataType)>>(),
+        );
         options.file_extension = file_extension;
         options.schema = schema.as_ref().map(|x| &x.0);
 
@@ -882,7 +881,7 @@ impl PySessionContext {
                 table_partition_cols
                     .into_iter()
                     .map(|(name, ty)| (name, ty.0))
-                    .collect::<Vec<(String, DataType)>>()
+                    .collect::<Vec<(String, DataType)>>(),
             )
             .file_compression_type(parse_file_compression_type(file_compression_type)?);
         options.schema_infer_max_records = schema_infer_max_records;
@@ -936,7 +935,7 @@ impl PySessionContext {
                 table_partition_cols
                     .into_iter()
                     .map(|(name, ty)| (name, ty.0))
-                    .collect::<Vec<(String, DataType)>>()
+                    .collect::<Vec<(String, DataType)>>(),
             )
             .file_compression_type(parse_file_compression_type(file_compression_type)?);
         options.schema = schema.as_ref().map(|x| &x.0);
@@ -980,7 +979,7 @@ impl PySessionContext {
                 table_partition_cols
                     .into_iter()
                     .map(|(name, ty)| (name, ty.0))
-                    .collect::<Vec<(String, DataType)>>()
+                    .collect::<Vec<(String, DataType)>>(),
             )
             .parquet_pruning(parquet_pruning)
             .skip_metadata(skip_metadata);
@@ -1007,13 +1006,12 @@ impl PySessionContext {
         file_extension: &str,
         py: Python,
     ) -> PyDataFusionResult<PyDataFrame> {
-        let mut options = AvroReadOptions::default()
-            .table_partition_cols(
-                table_partition_cols
-                    .into_iter()
-                    .map(|(name, ty)| (name, ty.0))
-                    .collect::<Vec<(String, DataType)>>()
-            );
+        let mut options = AvroReadOptions::default().table_partition_cols(
+            table_partition_cols
+                .into_iter()
+                .map(|(name, ty)| (name, ty.0))
+                .collect::<Vec<(String, DataType)>>(),
+        );
         options.file_extension = file_extension;
         let df = if let Some(schema) = schema {
             options.schema = Some(&schema.0);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1155

# Rationale for this change

Following [datafusion PR4221](https://github.com/apache/datafusion/pull/4221), this PR exposes the functionality in the python bindings

# What changes are included in this PR?

Change of the `table_partition_cols` arguments in `PySessionContext.register_listing_table`,
 `PySessionContext.register_parquet`, `PySessionContext.register_avro`, `PySessionContext.register_json`,
 `PySessionContext.read_parquet`, `PySessionContext.read_avro`, `PySessionContext.read_json`

# Are there any user-facing changes?

Yes, the signature of the functions above is changed
