### PR TITLE
Fix signature of `__arrow_c_stream__`

### DIFF
--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -1053,7 +1053,7 @@ class DataFrame:
         columns = list(columns)
         return DataFrame(self.df.unnest_columns(columns, preserve_nulls=preserve_nulls))
 
-    def __arrow_c_stream__(self, requested_schema: pa.Schema) -> Any:
+    def __arrow_c_stream__(self, requested_schema: object | None = None) -> object:
         """Export an Arrow PyCapsule Stream.
 
         This will execute and collect the DataFrame. We will attempt to respect the


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/datafusion-python/issues/1166.

# Rationale for this change

# What changes are included in this PR?

Add default argument to match specified signature: https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html#arrowstream-export

# Are there any user-facing changes?
No
