### PR TITLE
Add compression_level support to ParquetWriterOptions and enhance write_parquet to accept full options object

### DIFF
--- a/python/datafusion/__init__.py
+++ b/python/datafusion/__init__.py
@@ -46,11 +46,8 @@ from .context import (
     SessionContext,
     SQLOptions,
 )
-from .dataframe import (
-    DataFrame,
-    ParquetColumnOptions,
-    ParquetWriterOptions,
-)
+from .dataframe import DataFrame, ParquetColumnOptions, ParquetWriterOptions
+
 from .expr import (
     Expr,
     WindowFrame,

--- a/python/datafusion/__init__.py
+++ b/python/datafusion/__init__.py
@@ -46,7 +46,11 @@ from .context import (
     SessionContext,
     SQLOptions,
 )
-from .dataframe import DataFrame, ParquetColumnOptions, ParquetWriterOptions
+from .dataframe import (
+    DataFrame,
+    ParquetColumnOptions,
+    ParquetWriterOptions,
+)
 from .expr import (
     Expr,
     WindowFrame,

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -55,7 +55,6 @@ if TYPE_CHECKING:
     from datafusion._internal import DataFrame as DataFrameInternal
     from datafusion._internal import expr as expr_internal
 
-from dataclasses import dataclass
 from enum import Enum
 
 
@@ -192,6 +191,7 @@ class ParquetWriterOptions:
         writer_version: str = "1.0",
         skip_arrow_metadata: bool = False,
         compression: Optional[str] = "zstd(3)",
+        compression_level: Optional[int] = None,
         dictionary_enabled: Optional[bool] = True,
         dictionary_page_size_limit: int = 1024 * 1024,
         statistics_enabled: Optional[str] = "page",
@@ -214,7 +214,10 @@ class ParquetWriterOptions:
         self.write_batch_size = write_batch_size
         self.writer_version = writer_version
         self.skip_arrow_metadata = skip_arrow_metadata
-        self.compression = compression
+        if compression_level is not None:
+            self.compression = f"{compression}({compression_level})"
+        else:
+            self.compression = compression
         self.dictionary_enabled = dictionary_enabled
         self.dictionary_page_size_limit = dictionary_page_size_limit
         self.statistics_enabled = statistics_enabled

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from datafusion._internal import DataFrame as DataFrameInternal
     from datafusion._internal import expr as expr_internal
 
+from dataclasses import dataclass
 from enum import Enum
 
 
@@ -873,7 +874,7 @@ class DataFrame:
     def write_parquet(
         self,
         path: str | pathlib.Path,
-        compression: Union[str, Compression] = Compression.ZSTD,
+        compression: Union[str, Compression, ParquetWriterOptions] = Compression.ZSTD,
         compression_level: int | None = None,
     ) -> None:
         """Execute the :py:class:`DataFrame` and write the results to a Parquet file.
@@ -894,7 +895,13 @@ class DataFrame:
                 recommended range is 1 to 22, with the default being 4. Higher levels
                 provide better compression but slower speed.
         """
-        # Convert string to Compression enum if necessary
+        if isinstance(compression, ParquetWriterOptions):
+            if compression_level is not None:
+                msg = "compression_level should be None when using ParquetWriterOptions"
+                raise ValueError(msg)
+            self.write_parquet_with_options(path, compression)
+            return
+
         if isinstance(compression, str):
             compression = Compression.from_str(compression)
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -2038,6 +2038,22 @@ def test_write_parquet_with_options_column_options(df, tmp_path):
                 assert col["encodings"] == result["encodings"]
 
 
+def test_write_parquet_options(df, tmp_path):
+    options = ParquetWriterOptions(compression="gzip", compression_level=6)
+    df.write_parquet(str(tmp_path), options)
+
+    result = pq.read_table(str(tmp_path)).to_pydict()
+    expected = df.to_pydict()
+
+    assert result == expected
+
+
+def test_write_parquet_options_error(df, tmp_path):
+    options = ParquetWriterOptions(compression="gzip", compression_level=6)
+    with pytest.raises(ValueError):
+        df.write_parquet(str(tmp_path), options, compression_level=1)
+
+
 def test_dataframe_export(df) -> None:
     # Guarantees that we have the canonical implementation
     # reading our dataframe export


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1162

## Rationale for this change

This change enhances the flexibility of the Parquet writing process by allowing users to specify both compression type and compression level through a unified `ParquetWriterOptions` object. It also prevents conflicting configurations when options are explicitly passed.

## What changes are included in this PR?

- Added `compression_level` parameter to `ParquetWriterOptions`.
- Enhanced `DataFrame.write_parquet()` to accept a `ParquetWriterOptions` object.
- Added logic to prevent conflicting use of `compression_level` when using a full options object.
- Introduced two new tests:
  - `test_write_parquet_options`: Verifies functionality with custom compression and level.
  - `test_write_parquet_options_error`: Ensures proper error is raised for misconfiguration.

## Are these changes tested?

Yes, two new tests have been added:
- `test_write_parquet_options`: Confirms Parquet output matches expected data.
- `test_write_parquet_options_error`: Validates error handling when conflicting options are provided.

## Are there any user-facing changes?

Yes:
- Users can now pass a `ParquetWriterOptions` object directly to `DataFrame.write_parquet()`, allowing more granular control.
- A `ValueError` will be raised if `compression_level` is used with an already configured options object.

