### PR TITLE
Add support for automatic join column deduplication in DataFrame joins

### DIFF
--- a/docs/source/user-guide/common-operations/joins.rst
+++ b/docs/source/user-guide/common-operations/joins.rst
@@ -137,3 +137,11 @@ DataFusion uses the ``__right_<col>`` naming convention for conflicting columns 
 
     left.join(right, on="id", deduplicate=True)
 
+After deduplication, you can select the join column (which comes from the left DataFrame) and other columns as usual:
+
+.. ipython:: python
+
+    # Select the id column and other columns from both DataFrames
+    joined_dedup = left.join(right, on="id", deduplicate=True)
+    joined_dedup.select("id", "customer", "name")
+

--- a/docs/source/user-guide/common-operations/joins.rst
+++ b/docs/source/user-guide/common-operations/joins.rst
@@ -112,7 +112,8 @@ When you create a DataFrame with a ``name`` argument, that name is used as a pre
 
 .. ipython:: python
 
-    from datafusion import col
+    from datafusion import col, SessionContext
+    ctx = SessionContext() 
     left = ctx.from_pydict({"id": [1, 2]}, name="l")
     right = ctx.from_pydict({"id": [2, 3]}, name="r")
     joined = left.join(right, on="id")

--- a/docs/source/user-guide/common-operations/joins.rst
+++ b/docs/source/user-guide/common-operations/joins.rst
@@ -102,3 +102,33 @@ the right table.
 .. ipython:: python
 
     left.join(right, left_on="customer_id", right_on="id", how="anti")
+
+Disambiguating Columns
+----------------------
+
+When the join key exists in both DataFrames under the same name, the result contains two columns with that name. Assign a name to each DataFrame to use as a prefix and avoid ambiguity.
+
+.. ipython:: python
+
+    from datafusion import col
+    left = ctx.from_pydict({"id": [1, 2]}, name="l")
+    right = ctx.from_pydict({"id": [2, 3]}, name="r")
+    joined = left.join(right, on="id")
+    joined.select(col("l.id"), col("r.id"))
+
+You can remove the duplicate column after joining.
+
+.. ipython:: python
+
+    joined.drop("r.id")
+
+Automatic Deduplication
+----------------------
+
+Use the ``deduplicate`` argument of :py:meth:`DataFrame.join` to automatically
+drop the duplicate join column from the right DataFrame.
+
+.. ipython:: python
+
+    left.join(right, on="id", deduplicate=True)
+

--- a/docs/source/user-guide/common-operations/joins.rst
+++ b/docs/source/user-guide/common-operations/joins.rst
@@ -108,6 +108,8 @@ Disambiguating Columns
 
 When the join key exists in both DataFrames under the same name, the result contains two columns with that name. Assign a name to each DataFrame to use as a prefix and avoid ambiguity.
 
+When you create a DataFrame with a ``name`` argument, that name is used as a prefix in ``col("name.column")`` to reference specific columns.
+
 .. ipython:: python
 
     from datafusion import col
@@ -116,7 +118,9 @@ When the join key exists in both DataFrames under the same name, the result cont
     joined = left.join(right, on="id")
     joined.select(col("l.id"), col("r.id"))
 
-You can remove the duplicate column after joining.
+Note that the columns in the result appear in the same order as specified in the ``select()`` call.
+
+You can remove the duplicate column after joining. Note that ``drop()`` returns a new DataFrame (DataFusion's API is immutable).
 
 .. ipython:: python
 
@@ -126,7 +130,8 @@ Automatic Deduplication
 ----------------------
 
 Use the ``deduplicate`` argument of :py:meth:`DataFrame.join` to automatically
-drop the duplicate join column from the right DataFrame.
+drop the duplicate join column from the right DataFrame. Unlike PySpark which uses a ``_`` suffix by default, 
+DataFusion uses the ``__right_<col>`` naming convention for conflicting columns when not using deduplication.
 
 .. ipython:: python
 

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -811,7 +811,7 @@ class DataFrame:
             and isinstance(on[0], list)
             and isinstance(on[1], list)
         ):
-            # We know this is safe because we've checked the types            
+            # We know this is safe because we've checked the types
             join_keys = on  # type: ignore[assignment]
             resolved_on = None
         else:

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -811,6 +811,7 @@ class DataFrame:
             and isinstance(on[0], list)
             and isinstance(on[1], list)
         ):
+            # We know this is safe because we've checked the types            
             join_keys = on  # type: ignore[assignment]
             resolved_on = None
         else:

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -781,16 +781,31 @@ class DataFrame:
     def _prepare_deduplicate(
         self, right: DataFrame, on: str | Sequence[str]
     ) -> tuple[DataFrame, list[str], list[str], list[str]]:
-        """Rename join columns to drop them after joining."""
+        """Rename join columns to drop them after joining.
+        
+        Args:
+            right: The right DataFrame to modify.
+            on: The join column name(s).
+            
+        Returns:
+            A tuple containing:
+            - modified_right: DataFrame with renamed join columns
+            - drop_cols: List of column names to drop after joining  
+            - left_cols: List of original left DataFrame column names
+            - right_aliases: List of renamed right DataFrame column names
+        """
         drop_cols: list[str] = []
         right_aliases: list[str] = []
         on_cols = [on] if isinstance(on, str) else list(on)
+        
+        modified_right = right
         for col_name in on_cols:
             alias = f"__right_{col_name}"
-            right = right.with_column_renamed(col_name, alias)
+            modified_right = modified_right.with_column_renamed(col_name, alias)
             right_aliases.append(alias)
             drop_cols.append(alias)
-        return right, drop_cols, on_cols, right_aliases
+            
+        return modified_right, drop_cols, on_cols, right_aliases
 
     def join_on(
         self,

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -759,16 +759,25 @@ class DataFrame:
 
         if resolved_on is not None:
             if left_on is not None or right_on is not None:
-                error_msg = "`left_on` or `right_on` should not provided with `on`"
+                error_msg = (
+                    "`left_on` or `right_on` should not be provided with `on`. "
+                    "Note: `deduplicate` must be specified as a keyword argument."
+                )
                 raise ValueError(error_msg)
             left_on = resolved_on
             right_on = resolved_on
         elif left_on is not None or right_on is not None:
             if left_on is None or right_on is None:
-                error_msg = "`left_on` and `right_on` should both be provided."
+                error_msg = (
+                    "`left_on` and `right_on` should both be provided. "
+                    "Note: `deduplicate` must be specified as a keyword argument."
+                )
                 raise ValueError(error_msg)
         else:
-            error_msg = "either `on` or `left_on` and `right_on` should be provided."
+            error_msg = (
+                "Either `on` or both `left_on` and `right_on` should be provided. "
+                "Note: `deduplicate` must be specified as a keyword argument."
+            )
             raise ValueError(error_msg)
 
         # At this point, left_on and right_on are guaranteed to be non-None

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -558,7 +558,7 @@ def test_join_deduplicate_multi():
     right = ctx.create_dataframe([[batch]], "r")
 
     joined = left.join(right, on=["a", "b"], deduplicate=True)
-    joined = joined.sort(column("a"))
+    joined = joined.sort([column("a"), column("b")])
     table = pa.Table.from_batches(joined.collect())
 
     expected = {"a": [1, 2], "b": [3, 4], "r": ["u", "v"], "l": ["x", "y"]}

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -1940,7 +1940,6 @@ def test_write_parquet_with_options_encoding(tmp_path, encoding, data_types, res
             data["float"] = [1.01, 2.02, 3.03]
         elif data_type == "str":
             data["str"] = ["a", "b", "c"]
-
         elif data_type == "bool":
             data["bool"] = [True, False, True]
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -2640,29 +2640,31 @@ def test_collect_interrupted():
 def test_join_deduplicate_select():
     """Test that select works correctly after a deduplicated join."""
     ctx = SessionContext()
-    
+
     left_df = ctx.from_pydict({"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"]})
-    right_df = ctx.from_pydict({"id": [2, 3, 4], "city": ["New York", "London", "Paris"]})
-    
+    right_df = ctx.from_pydict(
+        {"id": [2, 3, 4], "city": ["New York", "London", "Paris"]}
+    )
+
     # Join and select the id column to confirm it works
-    joined_df = left_df.join(right_df, on="id")
+    joined_df = left_df.join(right_df, on="id", deduplicate=True)
     selected_df = joined_df.select(column("id"))
     result = selected_df.collect()[0]
-    
+
     # Should have only the matching ids (2, 3)
     expected_ids = [2, 3]
     assert result.column(0).to_pylist() == expected_ids
-    
+
     # Also test selecting multiple columns
     multi_select_df = joined_df.select(column("id"), column("name"), column("city"))
     multi_result = multi_select_df.collect()[0]
-    
+
     expected_data = {
         "id": [2, 3],
-        "name": ["Bob", "Charlie"], 
-        "city": ["New York", "London"]
+        "name": ["Bob", "Charlie"],
+        "city": ["New York", "London"],
     }
-    
+
     assert multi_result.column(0).to_pylist() == expected_data["id"]
     assert multi_result.column(1).to_pylist() == expected_data["name"]
     assert multi_result.column(2).to_pylist() == expected_data["city"]

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -42,7 +42,6 @@ from datafusion.dataframe_formatter import (
     configure_formatter,
     get_formatter,
     reset_formatter,
-    reset_styles_loaded_state,
 )
 from datafusion.expr import Window
 from pyarrow.csv import write_csv
@@ -2177,27 +2176,15 @@ def test_html_formatter_shared_styles(df, clean_formatter_state):
     # First, ensure we're using shared styles
     configure_formatter(use_shared_styles=True)
 
-    # Get HTML output for first table - should include styles
     html_first = df._repr_html_()
-
-    # Verify styles are included in first render
-    assert "<style>" in html_first
-    assert ".expandable-container" in html_first
-
-    # Get HTML output for second table - should NOT include styles
     html_second = df._repr_html_()
 
-    # Verify styles are NOT included in second render
+    assert "<script>" in html_first
+    assert "df-styles" in html_first
+    assert "<script>" in html_second
+    assert "df-styles" in html_second
+    assert "<style>" not in html_first
     assert "<style>" not in html_second
-    assert ".expandable-container" not in html_second
-
-    # Reset the styles loaded state and verify styles are included again
-    reset_styles_loaded_state()
-    html_after_reset = df._repr_html_()
-
-    # Verify styles are included after reset
-    assert "<style>" in html_after_reset
-    assert ".expandable-container" in html_after_reset
 
 
 def test_html_formatter_no_shared_styles(df, clean_formatter_state):
@@ -2206,15 +2193,15 @@ def test_html_formatter_no_shared_styles(df, clean_formatter_state):
     # Configure formatter to NOT use shared styles
     configure_formatter(use_shared_styles=False)
 
-    # Generate HTML multiple times
     html_first = df._repr_html_()
     html_second = df._repr_html_()
 
-    # Verify styles are included in both renders
-    assert "<style>" in html_first
-    assert "<style>" in html_second
-    assert ".expandable-container" in html_first
-    assert ".expandable-container" in html_second
+    assert "<script>" in html_first
+    assert "<script>" in html_second
+    assert "df-styles" in html_first
+    assert "df-styles" in html_second
+    assert "<style>" not in html_first
+    assert "<style>" not in html_second
 
 
 def test_html_formatter_manual_format_html(clean_formatter_state):
@@ -2228,20 +2215,15 @@ def test_html_formatter_manual_format_html(clean_formatter_state):
 
     formatter = get_formatter()
 
-    # First call should include styles
     html_first = formatter.format_html([batch], batch.schema)
-    assert "<style>" in html_first
-
-    # Second call should not include styles (using shared styles by default)
     html_second = formatter.format_html([batch], batch.schema)
+
+    assert "<script>" in html_first
+    assert "<script>" in html_second
+    assert "df-styles" in html_first
+    assert "df-styles" in html_second
+    assert "<style>" not in html_first
     assert "<style>" not in html_second
-
-    # Reset loaded state
-    reset_styles_loaded_state()
-
-    # After reset, styles should be included again
-    html_reset = formatter.format_html([batch], batch.schema)
-    assert "<style>" in html_reset
 
     # Create a new formatter with shared_styles=False
     local_formatter = DataFrameHtmlFormatter(use_shared_styles=False)
@@ -2250,8 +2232,12 @@ def test_html_formatter_manual_format_html(clean_formatter_state):
     local_html_1 = local_formatter.format_html([batch], batch.schema)
     local_html_2 = local_formatter.format_html([batch], batch.schema)
 
-    assert "<style>" in local_html_1
-    assert "<style>" in local_html_2
+    assert "<script>" in local_html_1
+    assert "<script>" in local_html_2
+    assert "df-styles" in local_html_1
+    assert "df-styles" in local_html_2
+    assert "<style>" not in local_html_1
+    assert "<style>" not in local_html_2
 
 
 def test_fill_null_basic(null_df):


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1173

## Rationale for this change

This change improves usability and interoperability by adding an optional `deduplicate=True` flag to DataFrame joins. In many real-world datasets, join keys exist in both tables with the same name. Prior to this PR, this resulted in conflicting column names in the output and required manual disambiguation or column renaming.

This feature aligns with the behavior in other DataFrame libraries like PySpark, making joins easier and more intuitive for users by optionally removing duplicate join columns from the right-hand side.

## What changes are included in this PR?

- Introduced a `deduplicate` argument to the `DataFrame.join()` method.
- Refactored join key resolution into a `_prepare_join` helper method.
- Implemented `_deduplicate_right` logic to rename right-hand join keys with unique aliases.
- Automatically drops aliased join columns after use.
- Applies `coalesce` to resolve `null` values in outer/right joins.
- Updated the user guide with documentation and examples of disambiguation and deduplication.
- Added comprehensive tests for:
  - Basic deduplication
  - Multi-column joins with deduplication
  - Select behavior post-join
  - All supported join types (inner, left, right, full)

## Are these changes tested?

✅ Yes. Tests are included to verify:
- Join outputs match expectations with and without deduplication.
- Correct schema after deduplication.
- Select operations behave as expected post-join.
- All supported join types are covered.

## Are there any user-facing changes?

✅ Yes. A new `deduplicate` keyword argument is available for `DataFrame.join()`. When enabled, it automatically removes duplicate join columns from the right DataFrame, simplifying common workflows and avoiding column naming conflicts.

This feature is backward-compatible and opt-in.

📘 User documentation has been updated with detailed usage examples, best practices, and behavior notes.
