### PR TITLE
Update CI rules

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,8 +31,11 @@ github:
     issues: true
   protected_branches:
     main:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
+      required_status_checks:
+        # require branches to be up-to-date before merging
+        strict: true
+        # don't require any jobs to pass
+        contexts: []
 
 staging:
   whoami: asf-staging


### PR DESCRIPTION
# Which issue does this PR close?

None

 # Rationale for this change

This PR copies the configuration of the `arrow-rs` repository. It does not require a committer to sign off on every PR but it does require that all branches are up to date. This is based on a discussion with another PMC member about the speed of development in this repository. The goal is to balance having some protection on the main branch and also allowing work to not be held up.

# What changes are included in this PR?

Update asf.yaml file.

# Are there any user-facing changes?

None