### PR TITLE
Improve `show()` output for empty DataFrames

### DIFF
--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -2664,3 +2664,32 @@ def test_collect_interrupted():
 
     # Make sure the interrupt thread has finished
     interrupt_thread.join(timeout=1.0)
+
+
+def test_show_from_empty_rows(capsys):
+    """Create a DataFrame with a valid schema but zero rows and call show().
+
+    This verifies that showing an empty-but-schema'd DataFrame does not panic
+    and prints a helpful message instead.
+    """
+    # duplicate of test_show_empty; covered elsewhere
+    pass
+
+
+def test_select_where_no_rows(capsys):
+    """Create a DataFrame a:[1,2,3], filter with a>4 to produce zero rows and call show().
+
+    This verifies that a query returning zero rows does not trigger a panic and
+    instead prints a helpful message.
+    """
+    # duplicate of test_show_empty; covered elsewhere
+    pass
+
+
+def test_sql_select_where_no_rows(capsys):
+    """Register a table 't' with a:[1,2,3], run SQL that returns no rows, and call show().
+
+    Ensures SQL path that returns zero rows doesn't panic when showing results.
+    """
+    # duplicate of test_show_empty; covered elsewhere
+    pass

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -252,6 +252,13 @@ def test_filter(df):
     assert result.column(2) == pa.array([5])
 
 
+def test_show_empty(df, capsys):
+    df_empty = df.filter(column("a") > literal(3))
+    df_empty.show()
+    captured = capsys.readouterr()
+    assert "DataFrame has no rows" in captured.out
+
+
 def test_sort(df):
     df = df.sort(column("b").sort(ascending=False))
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -2665,31 +2665,17 @@ def test_collect_interrupted():
     # Make sure the interrupt thread has finished
     interrupt_thread.join(timeout=1.0)
 
-
-def test_show_from_empty_rows(capsys):
-    """Create a DataFrame with a valid schema but zero rows and call show().
-
-    This verifies that showing an empty-but-schema'd DataFrame does not panic
-    and prints a helpful message instead.
-    """
-    # duplicate of test_show_empty; covered elsewhere
-    pass
+def test_show_select_where_no_rows(capsys) -> None:
+    ctx = SessionContext()
+    df = ctx.sql("SELECT 1 WHERE 1=0")
+    df.show()
+    out = capsys.readouterr().out
+    assert "DataFrame has no rows" in out
 
 
-def test_select_where_no_rows(capsys):
-    """Create a DataFrame a:[1,2,3], filter with a>4 to produce zero rows and call show().
-
-    This verifies that a query returning zero rows does not trigger a panic and
-    instead prints a helpful message.
-    """
-    # duplicate of test_show_empty; covered elsewhere
-    pass
-
-
-def test_sql_select_where_no_rows(capsys):
-    """Register a table 't' with a:[1,2,3], run SQL that returns no rows, and call show().
-
-    Ensures SQL path that returns zero rows doesn't panic when showing results.
-    """
-    # duplicate of test_show_empty; covered elsewhere
-    pass
+def test_show_from_empty_batch(capsys) -> None:
+    ctx = SessionContext()
+    batch = pa.record_batch([pa.array([], type=pa.int32())], names=["a"])
+    ctx.create_dataframe([[batch]]).show()
+    out = capsys.readouterr().out
+    assert "| a |" in out

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -998,10 +998,13 @@ impl PyDataFrame {
 fn print_dataframe(py: Python, df: DataFrame) -> PyDataFusionResult<()> {
     // Get string representation of record batches
     let batches = wait_for_future(py, df.collect())??;
-    let batches_as_string = pretty::pretty_format_batches(&batches);
-    let result = match batches_as_string {
-        Ok(batch) => format!("DataFrame()\n{batch}"),
-        Err(err) => format!("Error: {:?}", err.to_string()),
+    let result = if batches.is_empty() {
+        "DataFrame has no rows".to_string()
+    } else {
+        match pretty::pretty_format_batches(&batches) {
+            Ok(batch) => format!("DataFrame()\n{batch}"),
+            Err(err) => format!("Error: {:?}", err.to_string()),
+        }
     };
 
     // Import the Python 'builtins' module to access the print function


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #1207 

## Rationale for this change

When calling `show()` on a DataFrame with no rows, the current output may be misleading or unclear. This PR enhances the user experience by providing a clear message indicating that the DataFrame has no rows. This makes debugging and usage more intuitive, especially in cases where filters or queries return empty results.

## What changes are included in this PR?

* Added a conditional check in `print_dataframe` to handle the case where `DataFrame.collect()` returns no batches.
* If the DataFrame has no rows, output "DataFrame has no rows".
* Added tests for various scenarios:

  * Showing an empty DataFrame after filtering.
  * Showing the result of a `SELECT` query that returns no rows.
  * Showing an empty record batch with defined schema.

## Are these changes tested?

Yes, comprehensive tests have been added using `capsys` to verify the `show()` output under multiple empty DataFrame scenarios:

* `test_show_empty`
* `test_show_select_where_no_rows`
* `test_show_from_empty_batch`

## Are there any user-facing changes?

Yes:

* When `show()` is called on an empty DataFrame, the output is now: `DataFrame has no rows`
* This is a user-friendly message replacing a potentially confusing blank or improperly formatted output.

<!-- If there are any breaking changes to public APIs, please add the `api change` label. -->
