### PR TITLE
Set fail on warning for documentation generation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -35,4 +35,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) --fail-on-warning


### PR DESCRIPTION
# Which issue does this PR close?

None

 # Rationale for this change

Currently we are generating warnings in our site documentation generation. This can lead to poor site building, as the documentation should always build cleanly. This sets warnings to generate an error so the CI pipeline will fail.

# What changes are included in this PR?

- Sets warnings to error the pipeline
- Fix the current warnings

# Are there any user-facing changes?

No