### PR TITLE
docs: fix CaseBuilder documentation example

### DIFF
--- a/python/datafusion/expr.py
+++ b/python/datafusion/expr.py
@@ -1246,7 +1246,7 @@ class CaseBuilder:
         import datafusion.functions as f
         from datafusion import lit, col
         df.select(
-            f.case(col("column_a")
+            f.case(col("column_a"))
             .when(lit(1), lit("One"))
             .when(lit(2), lit("Two"))
             .otherwise(lit("Unknown"))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1176 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

Resolves the `df.select( ^ SyntaxError: '(' was never closed` error in the example found in the [**datafusion.expr.CaseBuilder**](https://datafusion.apache.org/python/autoapi/datafusion/expr/index.html#datafusion.expr.CaseBuilder) example.