### PR TITLE
Fix drop() method to handle quoted column names consistently

### DIFF
--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -415,7 +415,14 @@ class DataFrame:
         Returns:
             DataFrame with those columns removed in the projection.
         """
-        return DataFrame(self.df.drop(*columns))
+        normalized_columns = []
+        for col in columns:
+            if col.startswith('"') and col.endswith('"'):
+                normalized_columns.append(col.strip('"')) # Removes quotes from both sides of col
+            else:
+                normalized_columns.append(col)
+        
+        return DataFrame(self.df.drop(*normalized_columns))
 
     def filter(self, *predicates: Expr) -> DataFrame:
         """Return a DataFrame for which ``predicate`` evaluates to ``True``.

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -409,11 +409,20 @@ class DataFrame:
     def drop(self, *columns: str) -> DataFrame:
         """Drop arbitrary amount of columns.
 
+        Column names are case-sensitive and do not require double quotes like 
+        other operations such as `select`. Leading and trailing double quotes 
+        are allowed and will be automatically stripped if present.
+
         Args:
-            columns: Column names to drop from the dataframe.
+            columns: Column names to drop from the dataframe. Both 'column_name' 
+                    and '"column_name"' are accepted.
 
         Returns:
             DataFrame with those columns removed in the projection.
+            
+        Example Usage:
+            df.drop('ID_For_Students')      # Works
+            df.drop('"ID_For_Students"')    # Also works (quotes stripped)
         """
         normalized_columns = []
         for col in columns:

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -409,28 +409,29 @@ class DataFrame:
     def drop(self, *columns: str) -> DataFrame:
         """Drop arbitrary amount of columns.
 
-        Column names are case-sensitive and do not require double quotes like 
-        other operations such as `select`. Leading and trailing double quotes 
+        Column names are case-sensitive and do not require double quotes like
+        other operations such as `select`. Leading and trailing double quotes
         are allowed and will be automatically stripped if present.
 
         Args:
-            columns: Column names to drop from the dataframe. Both 'column_name' 
-                    and '"column_name"' are accepted.
+            columns: Column names to drop from the dataframe. Both ``column_name``
+                    and ``"column_name"`` are accepted.
 
         Returns:
             DataFrame with those columns removed in the projection.
-            
-        Example Usage:
+
+        Example Usage::
+
             df.drop('ID_For_Students')      # Works
             df.drop('"ID_For_Students"')    # Also works (quotes stripped)
         """
         normalized_columns = []
         for col in columns:
             if col.startswith('"') and col.endswith('"'):
-                normalized_columns.append(col.strip('"')) # Removes quotes from both sides of col
+                normalized_columns.append(col.strip('"'))  # Strip double quotes
             else:
                 normalized_columns.append(col)
-        
+
         return DataFrame(self.df.drop(*normalized_columns))
 
     def filter(self, *predicates: Expr) -> DataFrame:

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -216,7 +216,16 @@ def test_select(df):
     assert result.column(0) == pa.array([4, 5, 6])
     assert result.column(1) == pa.array([1, 2, 3])
 
+def test_drop_quoted_columns():
+    ctx = SessionContext()
+    batch = pa.RecordBatch.from_arrays([pa.array([1, 2, 3])], names=["ID_For_Students"])
+    df = ctx.create_dataframe([[batch]])
+    
+    # Both should work
+    assert df.drop('"ID_For_Students"').schema().names == []
+    assert df.drop('ID_For_Students').schema().names == []
 
+    
 def test_select_mixed_expr_string(df):
     df = df.select(column("b"), "a")
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -216,16 +216,17 @@ def test_select(df):
     assert result.column(0) == pa.array([4, 5, 6])
     assert result.column(1) == pa.array([1, 2, 3])
 
+
 def test_drop_quoted_columns():
     ctx = SessionContext()
     batch = pa.RecordBatch.from_arrays([pa.array([1, 2, 3])], names=["ID_For_Students"])
     df = ctx.create_dataframe([[batch]])
-    
+
     # Both should work
     assert df.drop('"ID_For_Students"').schema().names == []
-    assert df.drop('ID_For_Students').schema().names == []
+    assert df.drop("ID_For_Students").schema().names == []
 
-    
+
 def test_select_mixed_expr_string(df):
     df = df.select(column("b"), "a")
 


### PR DESCRIPTION
- Strip quotes from column names in drop() method
- Maintains consistency with other DataFrame operations
- Both drop('col') and drop('col') now work

Rationale: CSV files with capitalized headers require quotes in `select()` operations but `drop()` failed when quotes were provided, creating inconsistent behavior across DataFrame methods.

User facing changes: users can now use either `drop('col')` or `drop('"col"')` consistently, matching the behavior of other DataFrame operations like `select()`.

Closes #1212

This is one of my first PRs, please let me know what I can improve!



