### PR TITLE
Make most `pyclasses` frozen

### DIFF
--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -697,7 +697,10 @@ def test_array_function_obj_tests(stmt, py_expr):
             f.initcap(column("c")),
             pa.array(["Hello ", " World ", " !"], type=pa.string_view()),
         ),
-        (f.left(column("a"), literal(3)), pa.array(["Hel", "Wor", "!"])),
+        (
+            f.left(column("a"), literal(3)),
+            pa.array(["Hel", "Wor", "!"]),  # codespell:ignore
+        ),
         (f.length(column("c")), pa.array([6, 7, 2], type=pa.int32())),
         (f.lower(column("a")), pa.array(["hello", "world", "!"])),
         (f.lpad(column("a"), literal(7)), pa.array(["  Hello", "  World", "      !"])),

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -36,19 +36,19 @@ use std::any::Any;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-#[pyclass(name = "RawCatalog", module = "datafusion.catalog", subclass)]
+#[pyclass(frozen, name = "RawCatalog", module = "datafusion.catalog", subclass)]
 #[derive(Clone)]
 pub struct PyCatalog {
     pub catalog: Arc<dyn CatalogProvider>,
 }
 
-#[pyclass(name = "RawSchema", module = "datafusion.catalog", subclass)]
+#[pyclass(frozen, name = "RawSchema", module = "datafusion.catalog", subclass)]
 #[derive(Clone)]
 pub struct PySchema {
     pub schema: Arc<dyn SchemaProvider>,
 }
 
-#[pyclass(name = "RawTable", module = "datafusion.catalog", subclass)]
+#[pyclass(frozen, name = "RawTable", module = "datafusion.catalog", subclass)]
 #[derive(Clone)]
 pub struct PyTable {
     pub table: Arc<dyn TableProvider>,

--- a/src/common/data_type.rs
+++ b/src/common/data_type.rs
@@ -37,7 +37,7 @@ impl From<PyScalarValue> for ScalarValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "RexType", module = "datafusion.common")]
+#[pyclass(frozen, eq, eq_int, name = "RexType", module = "datafusion.common")]
 pub enum RexType {
     Alias,
     Literal,
@@ -56,6 +56,7 @@ pub enum RexType {
 /// and manageable location. Therefore this structure exists
 /// to map those types and provide a simple place for developers
 /// to map types from one system to another.
+// TODO: This looks like this needs pyo3 tracking so leaving unfrozen for now
 #[derive(Debug, Clone)]
 #[pyclass(name = "DataTypeMap", module = "datafusion.common", subclass)]
 pub struct DataTypeMap {
@@ -577,7 +578,7 @@ impl DataTypeMap {
 /// Since `DataType` exists in another package we cannot make that happen here so we wrap
 /// `DataType` as `PyDataType` This exists solely to satisfy those constraints.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(name = "DataType", module = "datafusion.common")]
+#[pyclass(frozen, name = "DataType", module = "datafusion.common")]
 pub struct PyDataType {
     pub data_type: DataType,
 }
@@ -635,7 +636,7 @@ impl From<DataType> for PyDataType {
 
 /// Represents the possible Python types that can be mapped to the SQL types
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "PythonType", module = "datafusion.common")]
+#[pyclass(frozen, eq, eq_int, name = "PythonType", module = "datafusion.common")]
 pub enum PythonType {
     Array,
     Bool,
@@ -655,7 +656,7 @@ pub enum PythonType {
 #[allow(non_camel_case_types)]
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "SqlType", module = "datafusion.common")]
+#[pyclass(frozen, eq, eq_int, name = "SqlType", module = "datafusion.common")]
 pub enum SqlType {
     ANY,
     ARRAY,
@@ -713,7 +714,13 @@ pub enum SqlType {
 #[allow(non_camel_case_types)]
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "NullTreatment", module = "datafusion.common")]
+#[pyclass(
+    frozen,
+    eq,
+    eq_int,
+    name = "NullTreatment",
+    module = "datafusion.common"
+)]
 pub enum NullTreatment {
     IGNORE_NULLS,
     RESPECT_NULLS,

--- a/src/common/data_type.rs
+++ b/src/common/data_type.rs
@@ -56,7 +56,7 @@ pub enum RexType {
 /// and manageable location. Therefore this structure exists
 /// to map those types and provide a simple place for developers
 /// to map types from one system to another.
-// TODO: This looks like this needs pyo3 tracking so leaving unfrozen for now
+// TODO: pyclass frozen
 #[derive(Debug, Clone)]
 #[pyclass(name = "DataTypeMap", module = "datafusion.common", subclass)]
 pub struct DataTypeMap {

--- a/src/common/df_schema.rs
+++ b/src/common/df_schema.rs
@@ -21,7 +21,7 @@ use datafusion::common::DFSchema;
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "DFSchema", module = "datafusion.common", subclass)]
+#[pyclass(frozen, name = "DFSchema", module = "datafusion.common", subclass)]
 pub struct PyDFSchema {
     schema: Arc<DFSchema>,
 }

--- a/src/common/function.rs
+++ b/src/common/function.rs
@@ -22,7 +22,7 @@ use pyo3::prelude::*;
 
 use super::data_type::PyDataType;
 
-#[pyclass(name = "SqlFunction", module = "datafusion.common", subclass)]
+#[pyclass(frozen, name = "SqlFunction", module = "datafusion.common", subclass)]
 #[derive(Debug, Clone)]
 pub struct SqlFunction {
     pub name: String,

--- a/src/common/schema.rs
+++ b/src/common/schema.rs
@@ -33,7 +33,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::{data_type::DataTypeMap, function::SqlFunction};
 
-// TODO I think the get/set prohibits frozen
+// TODO: pyclass frozen
 #[pyclass(name = "SqlSchema", module = "datafusion.common", subclass)]
 #[derive(Debug, Clone)]
 pub struct SqlSchema {
@@ -47,6 +47,7 @@ pub struct SqlSchema {
     pub functions: Vec<SqlFunction>,
 }
 
+// TODO: pyclass frozen
 #[pyclass(name = "SqlTable", module = "datafusion.common", subclass)]
 #[derive(Debug, Clone)]
 pub struct SqlTable {
@@ -91,6 +92,7 @@ impl SqlTable {
     }
 }
 
+// TODO: pyclass frozen
 #[pyclass(name = "SqlView", module = "datafusion.common", subclass)]
 #[derive(Debug, Clone)]
 pub struct SqlView {

--- a/src/common/schema.rs
+++ b/src/common/schema.rs
@@ -33,6 +33,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::{data_type::DataTypeMap, function::SqlFunction};
 
+// TODO I think the get/set prohibits frozen
 #[pyclass(name = "SqlSchema", module = "datafusion.common", subclass)]
 #[derive(Debug, Clone)]
 pub struct SqlSchema {
@@ -208,7 +209,7 @@ fn is_supported_push_down_expr(_expr: &Expr) -> bool {
     true
 }
 
-#[pyclass(name = "SqlStatistics", module = "datafusion.common", subclass)]
+#[pyclass(frozen, name = "SqlStatistics", module = "datafusion.common", subclass)]
 #[derive(Debug, Clone)]
 pub struct SqlStatistics {
     row_count: f64,
@@ -227,7 +228,7 @@ impl SqlStatistics {
     }
 }
 
-#[pyclass(name = "Constraints", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Constraints", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyConstraints {
     pub constraints: Constraints,
@@ -252,7 +253,7 @@ impl Display for PyConstraints {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "TableType", module = "datafusion.common")]
+#[pyclass(frozen, eq, eq_int, name = "TableType", module = "datafusion.common")]
 pub enum PyTableType {
     Base,
     View,
@@ -279,7 +280,7 @@ impl From<TableType> for PyTableType {
     }
 }
 
-#[pyclass(name = "TableSource", module = "datafusion.common", subclass)]
+#[pyclass(frozen, name = "TableSource", module = "datafusion.common", subclass)]
 #[derive(Clone)]
 pub struct PyTableSource {
     pub table_source: Arc<dyn TableSource>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,7 @@ use datafusion::config::ConfigOptions;
 use crate::errors::PyDataFusionResult;
 use crate::utils::py_obj_to_scalar_value;
 
+// TODO: Not frozen because set needs access
 #[pyclass(name = "Config", module = "datafusion", subclass)]
 #[derive(Clone)]
 pub(crate) struct PyConfig {
@@ -47,7 +48,7 @@ impl PyConfig {
     }
 
     /// Get a configuration option
-    pub fn get<'py>(&mut self, key: &str, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    pub fn get<'py>(&self, key: &str, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let options = self.config.to_owned();
         for entry in options.entries() {
             if entry.key == key {
@@ -65,7 +66,7 @@ impl PyConfig {
     }
 
     /// Get all configuration options
-    pub fn get_all(&mut self, py: Python) -> PyResult<PyObject> {
+    pub fn get_all(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let options = self.config.to_owned();
         for entry in options.entries() {
@@ -74,7 +75,7 @@ impl PyConfig {
         Ok(dict.into())
     }
 
-    fn __repr__(&mut self, py: Python) -> PyResult<String> {
+    fn __repr__(&self, py: Python) -> PyResult<String> {
         let dict = self.get_all(py);
         match dict {
             Ok(result) => Ok(format!("Config({result})")),

--- a/src/context.rs
+++ b/src/context.rs
@@ -77,7 +77,7 @@ use pyo3::IntoPyObjectExt;
 use tokio::task::JoinHandle;
 
 /// Configuration options for a SessionContext
-#[pyclass(name = "SessionConfig", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "SessionConfig", module = "datafusion", subclass)]
 #[derive(Clone, Default)]
 pub struct PySessionConfig {
     pub config: SessionConfig,
@@ -170,7 +170,7 @@ impl PySessionConfig {
 }
 
 /// Runtime options for a SessionContext
-#[pyclass(name = "RuntimeEnvBuilder", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "RuntimeEnvBuilder", module = "datafusion", subclass)]
 #[derive(Clone)]
 pub struct PyRuntimeEnvBuilder {
     pub builder: RuntimeEnvBuilder,
@@ -257,7 +257,7 @@ impl PyRuntimeEnvBuilder {
 }
 
 /// `PySQLOptions` allows you to specify options to the sql execution.
-#[pyclass(name = "SQLOptions", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "SQLOptions", module = "datafusion", subclass)]
 #[derive(Clone)]
 pub struct PySQLOptions {
     pub options: SQLOptions,

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -61,7 +61,7 @@ use crate::{
 // https://github.com/apache/datafusion-python/pull/1016#discussion_r1983239116
 // - we have not decided on the table_provider approach yet
 // this is an interim implementation
-#[pyclass(name = "TableProvider", module = "datafusion")]
+#[pyclass(frozen, name = "TableProvider", module = "datafusion")]
 pub struct PyTableProvider {
     provider: Arc<dyn TableProvider + Send>,
 }
@@ -188,7 +188,7 @@ fn build_formatter_config_from_python(formatter: &Bound<'_, PyAny>) -> PyResult<
 }
 
 /// Python mapping of `ParquetOptions` (includes just the writer-related options).
-#[pyclass(name = "ParquetWriterOptions", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "ParquetWriterOptions", module = "datafusion", subclass)]
 #[derive(Clone, Default)]
 pub struct PyParquetWriterOptions {
     options: ParquetOptions,
@@ -249,7 +249,7 @@ impl PyParquetWriterOptions {
 }
 
 /// Python mapping of `ParquetColumnOptions`.
-#[pyclass(name = "ParquetColumnOptions", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "ParquetColumnOptions", module = "datafusion", subclass)]
 #[derive(Clone, Default)]
 pub struct PyParquetColumnOptions {
     options: ParquetColumnOptions,
@@ -284,6 +284,7 @@ impl PyParquetColumnOptions {
 /// A PyDataFrame is a representation of a logical plan and an API to compose statements.
 /// Use it to build a plan and `.collect()` to execute the plan and collect the result.
 /// The actual execution of a plan runs natively on Rust and Arrow on a multi-threaded environment.
+// TODO: Not frozen because batches don't currently handle interior mutability
 #[pyclass(name = "DataFrame", module = "datafusion", subclass)]
 #[derive(Clone)]
 pub struct PyDataFrame {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -115,7 +115,7 @@ pub mod window;
 use sort_expr::{to_sort_expressions, PySortExpr};
 
 /// A PyExpr that can be used on a DataFrame
-#[pyclass(name = "RawExpr", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "RawExpr", module = "datafusion.expr", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyExpr {
     pub expr: Expr,
@@ -637,7 +637,7 @@ impl PyExpr {
     }
 }
 
-#[pyclass(name = "ExprFuncBuilder", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "ExprFuncBuilder", module = "datafusion.expr", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyExprFuncBuilder {
     pub builder: ExprFuncBuilder,

--- a/src/expr/aggregate.rs
+++ b/src/expr/aggregate.rs
@@ -28,7 +28,7 @@ use crate::errors::py_type_err;
 use crate::expr::PyExpr;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Aggregate", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Aggregate", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyAggregate {
     aggregate: Aggregate,

--- a/src/expr/aggregate_expr.rs
+++ b/src/expr/aggregate_expr.rs
@@ -20,7 +20,12 @@ use datafusion::logical_expr::expr::AggregateFunction;
 use pyo3::prelude::*;
 use std::fmt::{Display, Formatter};
 
-#[pyclass(name = "AggregateFunction", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "AggregateFunction",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyAggregateFunction {
     aggr: AggregateFunction,

--- a/src/expr/alias.rs
+++ b/src/expr/alias.rs
@@ -21,7 +21,7 @@ use std::fmt::{self, Display, Formatter};
 
 use datafusion::logical_expr::expr::Alias;
 
-#[pyclass(name = "Alias", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Alias", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyAlias {
     alias: Alias,

--- a/src/expr/analyze.rs
+++ b/src/expr/analyze.rs
@@ -23,7 +23,7 @@ use super::logical_node::LogicalNode;
 use crate::common::df_schema::PyDFSchema;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Analyze", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Analyze", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyAnalyze {
     analyze: Analyze,

--- a/src/expr/between.rs
+++ b/src/expr/between.rs
@@ -20,7 +20,7 @@ use datafusion::logical_expr::expr::Between;
 use pyo3::prelude::*;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "Between", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Between", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyBetween {
     between: Between,

--- a/src/expr/binary_expr.rs
+++ b/src/expr/binary_expr.rs
@@ -19,7 +19,7 @@ use crate::expr::PyExpr;
 use datafusion::logical_expr::BinaryExpr;
 use pyo3::prelude::*;
 
-#[pyclass(name = "BinaryExpr", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "BinaryExpr", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyBinaryExpr {
     expr: BinaryExpr,

--- a/src/expr/bool_expr.rs
+++ b/src/expr/bool_expr.rs
@@ -21,7 +21,7 @@ use std::fmt::{self, Display, Formatter};
 
 use super::PyExpr;
 
-#[pyclass(name = "Not", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Not", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyNot {
     expr: Expr,

--- a/src/expr/case.rs
+++ b/src/expr/case.rs
@@ -19,7 +19,7 @@ use crate::expr::PyExpr;
 use datafusion::logical_expr::Case;
 use pyo3::prelude::*;
 
-#[pyclass(name = "Case", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Case", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCase {
     case: Case,

--- a/src/expr/cast.rs
+++ b/src/expr/cast.rs
@@ -19,7 +19,7 @@ use crate::{common::data_type::PyDataType, expr::PyExpr};
 use datafusion::logical_expr::{Cast, TryCast};
 use pyo3::prelude::*;
 
-#[pyclass(name = "Cast", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Cast", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCast {
     cast: Cast,

--- a/src/expr/column.rs
+++ b/src/expr/column.rs
@@ -18,7 +18,7 @@
 use datafusion::common::Column;
 use pyo3::prelude::*;
 
-#[pyclass(name = "Column", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Column", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyColumn {
     pub col: Column,

--- a/src/expr/conditional_expr.rs
+++ b/src/expr/conditional_expr.rs
@@ -19,6 +19,7 @@ use crate::{errors::PyDataFusionResult, expr::PyExpr};
 use datafusion::logical_expr::conditional_expressions::CaseBuilder;
 use pyo3::prelude::*;
 
+// TODO: Can't make frozen because needs to mutate case_builder
 #[pyclass(name = "CaseBuilder", module = "datafusion.expr", subclass)]
 pub struct PyCaseBuilder {
     pub case_builder: CaseBuilder,

--- a/src/expr/conditional_expr.rs
+++ b/src/expr/conditional_expr.rs
@@ -19,7 +19,9 @@ use crate::{errors::PyDataFusionResult, expr::PyExpr};
 use datafusion::logical_expr::conditional_expressions::CaseBuilder;
 use pyo3::prelude::*;
 
-// TODO: Can't make frozen because needs to mutate case_builder
+// TODO: pyclass frozen
+// Mutates CaseBuilder might need CaseBuilder derive clone upstream
+// since when basically clones
 #[pyclass(name = "CaseBuilder", module = "datafusion.expr", subclass)]
 pub struct PyCaseBuilder {
     pub case_builder: CaseBuilder,

--- a/src/expr/copy_to.rs
+++ b/src/expr/copy_to.rs
@@ -28,7 +28,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "CopyTo", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "CopyTo", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCopyTo {
     copy: CopyTo,
@@ -114,7 +114,7 @@ impl PyCopyTo {
     }
 }
 
-#[pyclass(name = "FileType", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "FileType", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyFileType {
     file_type: Arc<dyn FileType>,

--- a/src/expr/create_catalog.rs
+++ b/src/expr/create_catalog.rs
@@ -27,7 +27,7 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "CreateCatalog", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "CreateCatalog", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCreateCatalog {
     create: CreateCatalog,

--- a/src/expr/create_catalog_schema.rs
+++ b/src/expr/create_catalog_schema.rs
@@ -27,7 +27,12 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "CreateCatalogSchema", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "CreateCatalogSchema",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyCreateCatalogSchema {
     create: CreateCatalogSchema,

--- a/src/expr/create_external_table.rs
+++ b/src/expr/create_external_table.rs
@@ -29,7 +29,12 @@ use crate::common::df_schema::PyDFSchema;
 
 use super::{logical_node::LogicalNode, sort_expr::PySortExpr};
 
-#[pyclass(name = "CreateExternalTable", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "CreateExternalTable",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyCreateExternalTable {
     create: CreateExternalTable,

--- a/src/expr/create_function.rs
+++ b/src/expr/create_function.rs
@@ -30,7 +30,7 @@ use super::PyExpr;
 use crate::common::{data_type::PyDataType, df_schema::PyDFSchema};
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "CreateFunction", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "CreateFunction", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCreateFunction {
     create: CreateFunction,
@@ -54,21 +54,31 @@ impl Display for PyCreateFunction {
     }
 }
 
-#[pyclass(name = "OperateFunctionArg", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "OperateFunctionArg",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyOperateFunctionArg {
     arg: OperateFunctionArg,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "Volatility", module = "datafusion.expr")]
+#[pyclass(frozen, eq, eq_int, name = "Volatility", module = "datafusion.expr")]
 pub enum PyVolatility {
     Immutable,
     Stable,
     Volatile,
 }
 
-#[pyclass(name = "CreateFunctionBody", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "CreateFunctionBody",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyCreateFunctionBody {
     body: CreateFunctionBody,

--- a/src/expr/create_index.rs
+++ b/src/expr/create_index.rs
@@ -27,7 +27,7 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::{logical_node::LogicalNode, sort_expr::PySortExpr};
 
-#[pyclass(name = "CreateIndex", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "CreateIndex", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCreateIndex {
     create: CreateIndex,

--- a/src/expr/create_memory_table.rs
+++ b/src/expr/create_memory_table.rs
@@ -24,7 +24,12 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "CreateMemoryTable", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "CreateMemoryTable",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyCreateMemoryTable {
     create: CreateMemoryTable,

--- a/src/expr/create_view.rs
+++ b/src/expr/create_view.rs
@@ -24,7 +24,7 @@ use crate::{errors::py_type_err, sql::logical::PyLogicalPlan};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "CreateView", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "CreateView", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCreateView {
     create: CreateView,

--- a/src/expr/describe_table.rs
+++ b/src/expr/describe_table.rs
@@ -28,7 +28,7 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "DescribeTable", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "DescribeTable", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDescribeTable {
     describe: DescribeTable,

--- a/src/expr/distinct.rs
+++ b/src/expr/distinct.rs
@@ -24,7 +24,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "Distinct", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Distinct", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDistinct {
     distinct: Distinct,

--- a/src/expr/dml.rs
+++ b/src/expr/dml.rs
@@ -24,7 +24,7 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "DmlStatement", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "DmlStatement", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDmlStatement {
     dml: DmlStatement,

--- a/src/expr/drop_catalog_schema.rs
+++ b/src/expr/drop_catalog_schema.rs
@@ -28,7 +28,12 @@ use crate::common::df_schema::PyDFSchema;
 use super::logical_node::LogicalNode;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "DropCatalogSchema", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "DropCatalogSchema",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyDropCatalogSchema {
     drop: DropCatalogSchema,

--- a/src/expr/drop_function.rs
+++ b/src/expr/drop_function.rs
@@ -27,7 +27,7 @@ use super::logical_node::LogicalNode;
 use crate::common::df_schema::PyDFSchema;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "DropFunction", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "DropFunction", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDropFunction {
     drop: DropFunction,

--- a/src/expr/drop_table.rs
+++ b/src/expr/drop_table.rs
@@ -24,7 +24,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "DropTable", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "DropTable", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDropTable {
     drop: DropTable,

--- a/src/expr/drop_view.rs
+++ b/src/expr/drop_view.rs
@@ -28,7 +28,7 @@ use crate::common::df_schema::PyDFSchema;
 use super::logical_node::LogicalNode;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "DropView", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "DropView", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDropView {
     drop: DropView,

--- a/src/expr/empty_relation.rs
+++ b/src/expr/empty_relation.rs
@@ -22,7 +22,7 @@ use std::fmt::{self, Display, Formatter};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "EmptyRelation", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "EmptyRelation", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyEmptyRelation {
     empty: EmptyRelation,

--- a/src/expr/exists.rs
+++ b/src/expr/exists.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 
 use super::subquery::PySubquery;
 
-#[pyclass(name = "Exists", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Exists", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyExists {
     exists: Exists,

--- a/src/expr/explain.rs
+++ b/src/expr/explain.rs
@@ -24,7 +24,7 @@ use crate::{common::df_schema::PyDFSchema, errors::py_type_err, sql::logical::Py
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "Explain", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Explain", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyExplain {
     explain: Explain,

--- a/src/expr/extension.rs
+++ b/src/expr/extension.rs
@@ -22,7 +22,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "Extension", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Extension", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyExtension {
     pub node: Extension,

--- a/src/expr/filter.rs
+++ b/src/expr/filter.rs
@@ -24,7 +24,7 @@ use crate::expr::logical_node::LogicalNode;
 use crate::expr::PyExpr;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Filter", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Filter", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyFilter {
     filter: Filter,

--- a/src/expr/grouping_set.rs
+++ b/src/expr/grouping_set.rs
@@ -18,7 +18,7 @@
 use datafusion::logical_expr::GroupingSet;
 use pyo3::prelude::*;
 
-#[pyclass(name = "GroupingSet", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "GroupingSet", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyGroupingSet {
     grouping_set: GroupingSet,

--- a/src/expr/in_list.rs
+++ b/src/expr/in_list.rs
@@ -19,7 +19,7 @@ use crate::expr::PyExpr;
 use datafusion::logical_expr::expr::InList;
 use pyo3::prelude::*;
 
-#[pyclass(name = "InList", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "InList", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyInList {
     in_list: InList,

--- a/src/expr/in_subquery.rs
+++ b/src/expr/in_subquery.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 
 use super::{subquery::PySubquery, PyExpr};
 
-#[pyclass(name = "InSubquery", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "InSubquery", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyInSubquery {
     in_subquery: InSubquery,

--- a/src/expr/indexed_field.rs
+++ b/src/expr/indexed_field.rs
@@ -22,7 +22,7 @@ use std::fmt::{Display, Formatter};
 
 use super::literal::PyLiteral;
 
-#[pyclass(name = "GetIndexedField", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "GetIndexedField", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyGetIndexedField {
     indexed_field: GetIndexedField,

--- a/src/expr/join.rs
+++ b/src/expr/join.rs
@@ -25,7 +25,7 @@ use crate::expr::{logical_node::LogicalNode, PyExpr};
 use crate::sql::logical::PyLogicalPlan;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[pyclass(name = "JoinType", module = "datafusion.expr")]
+#[pyclass(frozen, name = "JoinType", module = "datafusion.expr")]
 pub struct PyJoinType {
     join_type: JoinType,
 }
@@ -60,7 +60,7 @@ impl Display for PyJoinType {
 }
 
 #[derive(Debug, Clone, Copy)]
-#[pyclass(name = "JoinConstraint", module = "datafusion.expr")]
+#[pyclass(frozen, name = "JoinConstraint", module = "datafusion.expr")]
 pub struct PyJoinConstraint {
     join_constraint: JoinConstraint,
 }
@@ -87,7 +87,7 @@ impl PyJoinConstraint {
     }
 }
 
-#[pyclass(name = "Join", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Join", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyJoin {
     join: Join,

--- a/src/expr/like.rs
+++ b/src/expr/like.rs
@@ -21,7 +21,7 @@ use std::fmt::{self, Display, Formatter};
 
 use crate::expr::PyExpr;
 
-#[pyclass(name = "Like", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Like", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyLike {
     like: Like,
@@ -79,7 +79,7 @@ impl PyLike {
     }
 }
 
-#[pyclass(name = "ILike", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "ILike", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyILike {
     like: Like,
@@ -137,7 +137,7 @@ impl PyILike {
     }
 }
 
-#[pyclass(name = "SimilarTo", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "SimilarTo", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySimilarTo {
     like: Like,

--- a/src/expr/limit.rs
+++ b/src/expr/limit.rs
@@ -23,7 +23,7 @@ use crate::common::df_schema::PyDFSchema;
 use crate::expr::logical_node::LogicalNode;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Limit", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Limit", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyLimit {
     limit: Limit,

--- a/src/expr/literal.rs
+++ b/src/expr/literal.rs
@@ -19,7 +19,7 @@ use crate::errors::PyDataFusionError;
 use datafusion::{common::ScalarValue, logical_expr::expr::FieldMetadata};
 use pyo3::{prelude::*, IntoPyObjectExt};
 
-#[pyclass(name = "Literal", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Literal", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyLiteral {
     pub value: ScalarValue,
@@ -71,7 +71,7 @@ impl PyLiteral {
         extract_scalar_value!(self, Float64)
     }
 
-    pub fn value_decimal128(&mut self) -> PyResult<(Option<i128>, u8, i8)> {
+    pub fn value_decimal128(&self) -> PyResult<(Option<i128>, u8, i8)> {
         match &self.value {
             ScalarValue::Decimal128(value, precision, scale) => Ok((*value, *precision, *scale)),
             other => Err(unexpected_literal_value(other)),
@@ -122,7 +122,7 @@ impl PyLiteral {
         extract_scalar_value!(self, Time64Nanosecond)
     }
 
-    pub fn value_timestamp(&mut self) -> PyResult<(Option<i64>, Option<String>)> {
+    pub fn value_timestamp(&self) -> PyResult<(Option<i64>, Option<String>)> {
         match &self.value {
             ScalarValue::TimestampNanosecond(iv, tz)
             | ScalarValue::TimestampMicrosecond(iv, tz)

--- a/src/expr/placeholder.rs
+++ b/src/expr/placeholder.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 
 use crate::common::data_type::PyDataType;
 
-#[pyclass(name = "Placeholder", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Placeholder", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyPlaceholder {
     placeholder: Placeholder,

--- a/src/expr/projection.rs
+++ b/src/expr/projection.rs
@@ -25,7 +25,7 @@ use crate::expr::logical_node::LogicalNode;
 use crate::expr::PyExpr;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Projection", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Projection", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyProjection {
     pub projection: Projection,

--- a/src/expr/recursive_query.rs
+++ b/src/expr/recursive_query.rs
@@ -24,7 +24,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "RecursiveQuery", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "RecursiveQuery", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyRecursiveQuery {
     query: RecursiveQuery,

--- a/src/expr/repartition.rs
+++ b/src/expr/repartition.rs
@@ -24,13 +24,13 @@ use crate::{errors::py_type_err, sql::logical::PyLogicalPlan};
 
 use super::{logical_node::LogicalNode, PyExpr};
 
-#[pyclass(name = "Repartition", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Repartition", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyRepartition {
     repartition: Repartition,
 }
 
-#[pyclass(name = "Partitioning", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Partitioning", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyPartitioning {
     partitioning: Partitioning,

--- a/src/expr/scalar_subquery.rs
+++ b/src/expr/scalar_subquery.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 
 use super::subquery::PySubquery;
 
-#[pyclass(name = "ScalarSubquery", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "ScalarSubquery", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyScalarSubquery {
     subquery: Subquery,

--- a/src/expr/scalar_variable.rs
+++ b/src/expr/scalar_variable.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 
 use crate::common::data_type::PyDataType;
 
-#[pyclass(name = "ScalarVariable", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "ScalarVariable", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyScalarVariable {
     data_type: DataType,

--- a/src/expr/signature.rs
+++ b/src/expr/signature.rs
@@ -19,7 +19,7 @@ use datafusion::logical_expr::{TypeSignature, Volatility};
 use pyo3::prelude::*;
 
 #[allow(dead_code)]
-#[pyclass(name = "Signature", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Signature", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySignature {
     type_signature: TypeSignature,

--- a/src/expr/sort.rs
+++ b/src/expr/sort.rs
@@ -25,7 +25,7 @@ use crate::expr::logical_node::LogicalNode;
 use crate::expr::sort_expr::PySortExpr;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Sort", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Sort", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySort {
     sort: Sort,

--- a/src/expr/sort_expr.rs
+++ b/src/expr/sort_expr.rs
@@ -20,7 +20,7 @@ use datafusion::logical_expr::SortExpr;
 use pyo3::prelude::*;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "SortExpr", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "SortExpr", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySortExpr {
     pub(crate) sort: SortExpr,

--- a/src/expr/statement.rs
+++ b/src/expr/statement.rs
@@ -25,7 +25,12 @@ use crate::{common::data_type::PyDataType, sql::logical::PyLogicalPlan};
 
 use super::{logical_node::LogicalNode, PyExpr};
 
-#[pyclass(name = "TransactionStart", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "TransactionStart",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyTransactionStart {
     transaction_start: TransactionStart,
@@ -56,7 +61,13 @@ impl LogicalNode for PyTransactionStart {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "TransactionAccessMode", module = "datafusion.expr")]
+#[pyclass(
+    frozen,
+    eq,
+    eq_int,
+    name = "TransactionAccessMode",
+    module = "datafusion.expr"
+)]
 pub enum PyTransactionAccessMode {
     ReadOnly,
     ReadWrite,
@@ -84,6 +95,7 @@ impl TryFrom<PyTransactionAccessMode> for TransactionAccessMode {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[pyclass(
+    frozen,
     eq,
     eq_int,
     name = "TransactionIsolationLevel",
@@ -161,7 +173,7 @@ impl PyTransactionStart {
     }
 }
 
-#[pyclass(name = "TransactionEnd", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "TransactionEnd", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyTransactionEnd {
     transaction_end: TransactionEnd,
@@ -192,7 +204,13 @@ impl LogicalNode for PyTransactionEnd {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "TransactionConclusion", module = "datafusion.expr")]
+#[pyclass(
+    frozen,
+    eq,
+    eq_int,
+    name = "TransactionConclusion",
+    module = "datafusion.expr"
+)]
 pub enum PyTransactionConclusion {
     Commit,
     Rollback,
@@ -236,7 +254,7 @@ impl PyTransactionEnd {
     }
 }
 
-#[pyclass(name = "SetVariable", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "SetVariable", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySetVariable {
     set_variable: SetVariable,
@@ -284,7 +302,7 @@ impl PySetVariable {
     }
 }
 
-#[pyclass(name = "Prepare", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Prepare", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyPrepare {
     prepare: Prepare,
@@ -352,7 +370,7 @@ impl PyPrepare {
     }
 }
 
-#[pyclass(name = "Execute", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Execute", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyExecute {
     execute: Execute,
@@ -409,7 +427,7 @@ impl PyExecute {
     }
 }
 
-#[pyclass(name = "Deallocate", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Deallocate", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDeallocate {
     deallocate: Deallocate,

--- a/src/expr/subquery.rs
+++ b/src/expr/subquery.rs
@@ -24,7 +24,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "Subquery", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Subquery", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySubquery {
     subquery: Subquery,

--- a/src/expr/subquery_alias.rs
+++ b/src/expr/subquery_alias.rs
@@ -24,7 +24,7 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "SubqueryAlias", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "SubqueryAlias", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySubqueryAlias {
     subquery_alias: SubqueryAlias,

--- a/src/expr/table_scan.rs
+++ b/src/expr/table_scan.rs
@@ -24,7 +24,7 @@ use crate::expr::logical_node::LogicalNode;
 use crate::sql::logical::PyLogicalPlan;
 use crate::{common::df_schema::PyDFSchema, expr::PyExpr};
 
-#[pyclass(name = "TableScan", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "TableScan", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyTableScan {
     table_scan: TableScan,

--- a/src/expr/union.rs
+++ b/src/expr/union.rs
@@ -23,7 +23,7 @@ use crate::common::df_schema::PyDFSchema;
 use crate::expr::logical_node::LogicalNode;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Union", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Union", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyUnion {
     union_: Union,

--- a/src/expr/unnest.rs
+++ b/src/expr/unnest.rs
@@ -23,7 +23,7 @@ use crate::common::df_schema::PyDFSchema;
 use crate::expr::logical_node::LogicalNode;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Unnest", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Unnest", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyUnnest {
     unnest_: Unnest,

--- a/src/expr/unnest_expr.rs
+++ b/src/expr/unnest_expr.rs
@@ -21,7 +21,7 @@ use std::fmt::{self, Display, Formatter};
 
 use super::PyExpr;
 
-#[pyclass(name = "UnnestExpr", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "UnnestExpr", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyUnnestExpr {
     unnest: Unnest,

--- a/src/expr/values.rs
+++ b/src/expr/values.rs
@@ -25,7 +25,7 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::{logical_node::LogicalNode, PyExpr};
 
-#[pyclass(name = "Values", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Values", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyValues {
     values: Values,

--- a/src/expr/window.rs
+++ b/src/expr/window.rs
@@ -30,13 +30,13 @@ use std::fmt::{self, Display, Formatter};
 
 use super::py_expr_list;
 
-#[pyclass(name = "WindowExpr", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "WindowExpr", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyWindowExpr {
     window: Window,
 }
 
-#[pyclass(name = "WindowFrame", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "WindowFrame", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyWindowFrame {
     window_frame: WindowFrame,
@@ -54,7 +54,12 @@ impl From<WindowFrame> for PyWindowFrame {
     }
 }
 
-#[pyclass(name = "WindowFrameBound", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "WindowFrameBound",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyWindowFrameBound {
     frame_bound: WindowFrameBound,

--- a/src/physical_plan.rs
+++ b/src/physical_plan.rs
@@ -24,7 +24,7 @@ use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyBytes};
 
 use crate::{context::PySessionContext, errors::PyDataFusionResult};
 
-#[pyclass(name = "ExecutionPlan", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "ExecutionPlan", module = "datafusion", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyExecutionPlan {
     pub plan: Arc<dyn ExecutionPlan>,

--- a/src/record_batch.rs
+++ b/src/record_batch.rs
@@ -28,7 +28,7 @@ use pyo3::prelude::*;
 use pyo3::{pyclass, pymethods, PyObject, PyResult, Python};
 use tokio::sync::Mutex;
 
-#[pyclass(name = "RecordBatch", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "RecordBatch", module = "datafusion", subclass)]
 pub struct PyRecordBatch {
     batch: RecordBatch,
 }
@@ -46,7 +46,7 @@ impl From<RecordBatch> for PyRecordBatch {
     }
 }
 
-#[pyclass(name = "RecordBatchStream", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "RecordBatchStream", module = "datafusion", subclass)]
 pub struct PyRecordBatchStream {
     stream: Arc<Mutex<SendableRecordBatchStream>>,
 }
@@ -61,12 +61,12 @@ impl PyRecordBatchStream {
 
 #[pymethods]
 impl PyRecordBatchStream {
-    fn next(&mut self, py: Python) -> PyResult<PyRecordBatch> {
+    fn next(&self, py: Python) -> PyResult<PyRecordBatch> {
         let stream = self.stream.clone();
         wait_for_future(py, next_stream(stream, true))?
     }
 
-    fn __next__(&mut self, py: Python) -> PyResult<PyRecordBatch> {
+    fn __next__(&self, py: Python) -> PyResult<PyRecordBatch> {
         self.next(py)
     }
 

--- a/src/sql/logical.rs
+++ b/src/sql/logical.rs
@@ -63,7 +63,7 @@ use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyBytes};
 
 use crate::expr::logical_node::LogicalNode;
 
-#[pyclass(name = "LogicalPlan", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "LogicalPlan", module = "datafusion", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyLogicalPlan {
     pub(crate) plan: Arc<LogicalPlan>,

--- a/src/store.rs
+++ b/src/store.rs
@@ -36,7 +36,12 @@ pub enum StorageContexts {
     HTTP(PyHttpContext),
 }
 
-#[pyclass(name = "LocalFileSystem", module = "datafusion.store", subclass)]
+#[pyclass(
+    frozen,
+    name = "LocalFileSystem",
+    module = "datafusion.store",
+    subclass
+)]
 #[derive(Debug, Clone)]
 pub struct PyLocalFileSystemContext {
     pub inner: Arc<LocalFileSystem>,
@@ -62,7 +67,7 @@ impl PyLocalFileSystemContext {
     }
 }
 
-#[pyclass(name = "MicrosoftAzure", module = "datafusion.store", subclass)]
+#[pyclass(frozen, name = "MicrosoftAzure", module = "datafusion.store", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyMicrosoftAzureContext {
     pub inner: Arc<MicrosoftAzure>,
@@ -134,7 +139,7 @@ impl PyMicrosoftAzureContext {
     }
 }
 
-#[pyclass(name = "GoogleCloud", module = "datafusion.store", subclass)]
+#[pyclass(frozen, name = "GoogleCloud", module = "datafusion.store", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyGoogleCloudContext {
     pub inner: Arc<GoogleCloudStorage>,
@@ -164,7 +169,7 @@ impl PyGoogleCloudContext {
     }
 }
 
-#[pyclass(name = "AmazonS3", module = "datafusion.store", subclass)]
+#[pyclass(frozen, name = "AmazonS3", module = "datafusion.store", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyAmazonS3Context {
     pub inner: Arc<AmazonS3>,
@@ -223,7 +228,7 @@ impl PyAmazonS3Context {
     }
 }
 
-#[pyclass(name = "Http", module = "datafusion.store", subclass)]
+#[pyclass(frozen, name = "Http", module = "datafusion.store", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyHttpContext {
     pub url: String,

--- a/src/substrait.rs
+++ b/src/substrait.rs
@@ -27,7 +27,7 @@ use datafusion_substrait::serializer;
 use datafusion_substrait::substrait::proto::Plan;
 use prost::Message;
 
-#[pyclass(name = "Plan", module = "datafusion.substrait", subclass)]
+#[pyclass(frozen, name = "Plan", module = "datafusion.substrait", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyPlan {
     pub plan: Plan,
@@ -59,7 +59,7 @@ impl From<Plan> for PyPlan {
 /// A PySubstraitSerializer is a representation of a Serializer that is capable of both serializing
 /// a `LogicalPlan` instance to Substrait Protobuf bytes and also deserialize Substrait Protobuf bytes
 /// to a valid `LogicalPlan` instance.
-#[pyclass(name = "Serde", module = "datafusion.substrait", subclass)]
+#[pyclass(frozen, name = "Serde", module = "datafusion.substrait", subclass)]
 #[derive(Debug, Clone)]
 pub struct PySubstraitSerializer;
 
@@ -112,7 +112,7 @@ impl PySubstraitSerializer {
     }
 }
 
-#[pyclass(name = "Producer", module = "datafusion.substrait", subclass)]
+#[pyclass(frozen, name = "Producer", module = "datafusion.substrait", subclass)]
 #[derive(Debug, Clone)]
 pub struct PySubstraitProducer;
 
@@ -129,7 +129,7 @@ impl PySubstraitProducer {
     }
 }
 
-#[pyclass(name = "Consumer", module = "datafusion.substrait", subclass)]
+#[pyclass(frozen, name = "Consumer", module = "datafusion.substrait", subclass)]
 #[derive(Debug, Clone)]
 pub struct PySubstraitConsumer;
 

--- a/src/udaf.rs
+++ b/src/udaf.rs
@@ -155,7 +155,7 @@ pub fn to_rust_accumulator(accum: PyObject) -> AccumulatorFactoryFunction {
 }
 
 /// Represents an AggregateUDF
-#[pyclass(name = "AggregateUDF", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "AggregateUDF", module = "datafusion", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyAggregateUDF {
     pub(crate) function: AggregateUDF,

--- a/src/udf.rs
+++ b/src/udf.rs
@@ -81,7 +81,7 @@ fn to_scalar_function_impl(func: PyObject) -> ScalarFunctionImplementation {
 }
 
 /// Represents a PyScalarUDF
-#[pyclass(name = "ScalarUDF", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "ScalarUDF", module = "datafusion", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyScalarUDF {
     pub(crate) function: ScalarUDF,

--- a/src/udtf.rs
+++ b/src/udtf.rs
@@ -31,7 +31,7 @@ use pyo3::exceptions::PyNotImplementedError;
 use pyo3::types::{PyCapsule, PyTuple};
 
 /// Represents a user defined table function
-#[pyclass(name = "TableFunction", module = "datafusion")]
+#[pyclass(frozen, name = "TableFunction", module = "datafusion")]
 #[derive(Debug, Clone)]
 pub struct PyTableFunction {
     pub(crate) name: String,

--- a/src/udwf.rs
+++ b/src/udwf.rs
@@ -210,7 +210,7 @@ pub fn to_rust_partition_evaluator(evaluator: PyObject) -> PartitionEvaluatorFac
 }
 
 /// Represents an WindowUDF
-#[pyclass(name = "WindowUDF", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "WindowUDF", module = "datafusion", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyWindowUDF {
     pub(crate) function: WindowUDF,

--- a/src/unparser/dialect.rs
+++ b/src/unparser/dialect.rs
@@ -22,7 +22,7 @@ use datafusion::sql::unparser::dialect::{
 };
 use pyo3::prelude::*;
 
-#[pyclass(name = "Dialect", module = "datafusion.unparser", subclass)]
+#[pyclass(frozen, name = "Dialect", module = "datafusion.unparser", subclass)]
 #[derive(Clone)]
 pub struct PyDialect {
     pub dialect: Arc<dyn Dialect>,

--- a/src/unparser/mod.rs
+++ b/src/unparser/mod.rs
@@ -25,7 +25,7 @@ use pyo3::{exceptions::PyValueError, prelude::*};
 
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Unparser", module = "datafusion.unparser", subclass)]
+#[pyclass(frozen, name = "Unparser", module = "datafusion.unparser", subclass)]
 #[derive(Clone)]
 pub struct PyUnparser {
     dialect: Arc<dyn Dialect>,


### PR DESCRIPTION
# Which issue does this PR close?
Covers most of https://github.com/apache/datafusion-python/issues/1250

 # Rationale for this change
Previous PR fixed inability to use python threads around SessionContext https://github.com/apache/datafusion-python/pull/1248

Suggested that we mark all possible classes frozen to be more explicit/better thread support.

# What changes are included in this PR?
* Fix a typos setting that failed for me locally
* For all classes that don't mutate members just add frozen tag
* For two classes apply `Arc<Mutex` as a strategy to manage `Sync` and `frozen`
   * Maybe for PyConfig `RwLock` is better since we might be reading configs more than writing
* Left todos for remaining pyclasses
   * everything with `pyo3[(get,set)]` would require new wrapper code for each member if we think frozen makes sense
   * CaseBuilder was a bit messier. If we derive clone upstream then `Arc<Mutex` works decently. 

I don't expect anything here to be a major performance delta. It wasn't clear if there was a good way to check that. The benchmarks look more interested in datafusion vs other tools rather than comparing branches.

# Are there any user-facing changes?
There are no user-facing python changes. I'm don't think the wrapper code is considered public apis.