### PR TITLE
Freeze PyO3 wrappers & introduce interior mutability to avoid PyO3 borrow errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,6 +1594,7 @@ dependencies = [
  "log",
  "mimalloc",
  "object_store",
+ "parking_lot",
  "prost",
  "prost-types",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ futures = "0.3"
 object_store = { version = "0.12.3", features = ["aws", "gcp", "azure", "http"] }
 url = "2"
 log = "0.4.27"
+parking_lot = "0.12"
 
 [build-dependencies]
 prost-types = "0.13.1" # keep in line with `datafusion-substrait`

--- a/docs/source/contributor-guide/ffi.rst
+++ b/docs/source/contributor-guide/ffi.rst
@@ -137,6 +137,67 @@ and you want to create a sharable FFI counterpart, you could write:
     let my_provider = MyTableProvider::default();
     let ffi_provider = FFI_TableProvider::new(Arc::new(my_provider), false, None);
 
+.. _ffi_pyclass_mutability:
+
+PyO3 class mutability guidelines
+--------------------------------
+
+PyO3 bindings should present immutable wrappers whenever a struct stores shared or
+interior-mutable state. In practice this means that any ``#[pyclass]`` containing an
+``Arc<RwLock<_>>`` or similar synchronized primitive must opt into ``#[pyclass(frozen)]``
+unless there is a compelling reason not to.
+
+The :mod:`datafusion` configuration helpers illustrate the preferred pattern. The
+``PyConfig`` class in :file:`src/config.rs` stores an ``Arc<RwLock<ConfigOptions>>`` and is
+explicitly frozen so callers interact with configuration state through provided methods
+instead of mutating the container directly:
+
+.. code-block:: rust
+
+    #[pyclass(name = "Config", module = "datafusion", subclass, frozen)]
+    #[derive(Clone)]
+    pub(crate) struct PyConfig {
+        config: Arc<RwLock<ConfigOptions>>,
+    }
+
+The same approach applies to execution contexts. ``PySessionContext`` in
+:file:`src/context.rs` stays frozen even though it shares mutable state internally via
+``SessionContext``. This ensures PyO3 tracks borrows correctly while Python-facing APIs
+clone the inner ``SessionContext`` or return new wrappers instead of mutating the
+existing instance in place:
+
+.. code-block:: rust
+
+    #[pyclass(frozen, name = "SessionContext", module = "datafusion", subclass)]
+    #[derive(Clone)]
+    pub struct PySessionContext {
+        pub ctx: SessionContext,
+    }
+
+Occasionally a type must remain mutable—for example when PyO3 attribute setters need to
+update fields directly. In these rare cases add an inline justification so reviewers and
+future contributors understand why ``frozen`` is unsafe to enable. ``DataTypeMap`` in
+:file:`src/common/data_type.rs` includes such a comment because PyO3 still needs to track
+field updates:
+
+.. code-block:: rust
+
+    // TODO: This looks like this needs pyo3 tracking so leaving unfrozen for now
+    #[derive(Debug, Clone)]
+    #[pyclass(name = "DataTypeMap", module = "datafusion.common", subclass)]
+    pub struct DataTypeMap {
+        #[pyo3(get, set)]
+        pub arrow_type: PyDataType,
+        #[pyo3(get, set)]
+        pub python_type: PythonType,
+        #[pyo3(get, set)]
+        pub sql_type: SqlType,
+    }
+
+When reviewers encounter a mutable ``#[pyclass]`` without a comment, they should request
+an explanation or ask that ``frozen`` be added. Keeping these wrappers frozen by default
+helps avoid subtle bugs stemming from PyO3's interior mutability tracking.
+
 If you were interfacing with a library that provided the above ``FFI_TableProvider`` and
 you needed to turn it back into an ``TableProvider``, you can turn it into a
 ``ForeignTableProvider`` with implements the ``TableProvider`` trait.

--- a/docs/source/contributor-guide/introduction.rst
+++ b/docs/source/contributor-guide/introduction.rst
@@ -26,6 +26,10 @@ We welcome and encourage contributions of all kinds, such as:
 In addition to submitting new PRs, we have a healthy tradition of community members reviewing each other’s PRs.
 Doing so is a great way to help the community as well as get more familiar with Rust and the relevant codebases.
 
+Before opening a pull request that touches PyO3 bindings, please review the
+:ref:`PyO3 class mutability guidelines <ffi_pyclass_mutability>` so you can flag missing
+``#[pyclass(frozen)]`` annotations during development and review.
+
 How to develop
 --------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,9 @@ convention = "google"
 [tool.ruff.lint.pycodestyle]
 max-doc-length = 88
 
+[tool.ruff.lint.flake8-boolean-trap]
+extend-allowed-calls = ["lit", "datafusion.lit"]
+
 # Disable docstring checking for these directories
 [tool.ruff.lint.per-file-ignores]
 "python/tests/*" = [

--- a/python/tests/test_concurrency.py
+++ b/python/tests/test_concurrency.py
@@ -20,10 +20,9 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 
 import pyarrow as pa
-
 from datafusion import Config, SessionContext, col, lit
-from datafusion.common import SqlSchema
 from datafusion import functions as f
+from datafusion.common import SqlSchema
 
 
 def _run_in_threads(fn, count: int = 8) -> None:

--- a/python/tests/test_concurrency.py
+++ b/python/tests/test_concurrency.py
@@ -1,0 +1,102 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pyarrow as pa
+
+from datafusion import Config, SessionContext, col, lit
+from datafusion.common import SqlSchema
+from datafusion import functions as f
+
+
+def _run_in_threads(fn, count: int = 8) -> None:
+    with ThreadPoolExecutor(max_workers=count) as executor:
+        futures = [executor.submit(fn, i) for i in range(count)]
+        for future in futures:
+            # Propagate any exception raised in the worker thread.
+            future.result()
+
+
+def test_concurrent_access_to_shared_structures() -> None:
+    """Exercise SqlSchema, Config, and DataFrame concurrently."""
+
+    schema = SqlSchema("concurrency")
+    config = Config()
+    ctx = SessionContext()
+
+    batch = pa.record_batch([pa.array([1, 2, 3], type=pa.int32())], names=["value"])
+    df = ctx.create_dataframe([[batch]])
+
+    config_key = "datafusion.execution.batch_size"
+    expected_rows = batch.num_rows
+
+    def worker(index: int) -> None:
+        schema.name = f"concurrency-{index}"
+        assert schema.name.startswith("concurrency-")
+        # Exercise getters that use internal locks.
+        assert isinstance(schema.tables, list)
+        assert isinstance(schema.views, list)
+        assert isinstance(schema.functions, list)
+
+        config.set(config_key, str(1024 + index))
+        assert config.get(config_key) is not None
+        # Access the full config map to stress lock usage.
+        assert config_key in config.get_all()
+
+        batches = df.collect()
+        assert sum(batch.num_rows for batch in batches) == expected_rows
+
+    _run_in_threads(worker, count=12)
+
+
+def test_case_builder_reuse_from_multiple_threads() -> None:
+    """Ensure the case builder can be safely reused across threads."""
+
+    ctx = SessionContext()
+    values = pa.array([0, 1, 2, 3, 4], type=pa.int32())
+    df = ctx.create_dataframe([[pa.record_batch([values], names=["value"])]])
+
+    base_builder = f.case(col("value"))
+
+    def add_case(i: int) -> None:
+        base_builder.when(lit(i), lit(f"value-{i}"))
+
+    _run_in_threads(add_case, count=8)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        otherwise_future = executor.submit(base_builder.otherwise, lit("default"))
+        case_expr = otherwise_future.result()
+
+    result = df.select(case_expr.alias("label")).collect()
+    assert sum(batch.num_rows for batch in result) == len(values)
+
+    predicate_builder = f.when(col("value") == lit(0), lit("zero"))
+
+    def add_predicate(i: int) -> None:
+        predicate_builder.when(col("value") == lit(i + 1), lit(f"value-{i + 1}"))
+
+    _run_in_threads(add_predicate, count=4)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        end_future = executor.submit(predicate_builder.end)
+        predicate_expr = end_future.result()
+
+    result = df.select(predicate_expr.alias("label")).collect()
+    assert sum(batch.num_rows for batch in result) == len(values)

--- a/python/tests/test_concurrency.py
+++ b/python/tests/test_concurrency.py
@@ -99,7 +99,8 @@ def test_case_builder_reuse_from_multiple_threads() -> None:
     base_builder = f.case(col("value"))
 
     def add_case(i: int) -> None:
-        base_builder.when(lit(i), lit(f"value-{i}"))
+        nonlocal base_builder
+        base_builder = base_builder.when(lit(i), lit(f"value-{i}"))
 
     _run_in_threads(add_case, count=8)
 

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -20,6 +20,10 @@ from datetime import datetime, timezone
 
 import pyarrow as pa
 import pytest
+
+# Avoid passing boolean literals positionally (FBT003). Use a named constant
+# so linters don't see a bare True/False literal in a function call.
+_TRUE = True
 from datafusion import (
     SessionContext,
     col,
@@ -201,7 +205,7 @@ def test_expr_to_variant():
 
 
 def test_case_builder_error_preserves_builder_state():
-    case_builder = functions.when(lit(True), lit(1))
+    case_builder = functions.when(lit(_TRUE), lit(1))
 
     with pytest.raises(Exception) as exc_info:
         case_builder.otherwise(lit("bad"))
@@ -256,7 +260,7 @@ def test_case_builder_when_handles_are_independent():
     first_builder = base_builder.when(col("value") > lit(10), lit("gt10"))
     second_builder = base_builder.when(col("value") > lit(20), lit("gt20"))
 
-    first_builder = first_builder.when(lit(True), lit("final-one"))
+    first_builder = first_builder.when(lit(_TRUE), lit("final-one"))
 
     expr_first = first_builder.otherwise(lit("fallback-one")).alias("first")
     expr_second = second_builder.otherwise(lit("fallback-two")).alias("second")

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -54,10 +54,6 @@ from datafusion.expr import (
     ensure_expr_list,
 )
 
-# Avoid passing boolean literals positionally (FBT003). Use a named constant
-# so linters don't see a bare True/False literal in a function call.
-_TRUE = True
-
 
 @pytest.fixture
 def test_ctx():
@@ -206,7 +202,7 @@ def test_expr_to_variant():
 
 
 def test_case_builder_error_preserves_builder_state():
-    case_builder = functions.when(lit(_TRUE), lit(1))
+    case_builder = functions.when(lit(True), lit(1))
 
     with pytest.raises(Exception) as exc_info:
         case_builder.otherwise(lit("bad"))
@@ -261,7 +257,7 @@ def test_case_builder_when_handles_are_independent():
     first_builder = base_builder.when(col("value") > lit(10), lit("gt10"))
     second_builder = base_builder.when(col("value") > lit(20), lit("gt20"))
 
-    first_builder = first_builder.when(lit(_TRUE), lit("final-one"))
+    first_builder = first_builder.when(lit(True), lit("final-one"))
 
     expr_first = first_builder.otherwise(lit("fallback-one")).alias("first")
     expr_second = second_builder.otherwise(lit("fallback-two")).alias("second")
@@ -283,10 +279,10 @@ def test_case_builder_when_handles_are_independent():
 
 
 def test_case_builder_when_thread_safe():
-    case_builder = functions.when(lit(_TRUE), lit(1))
+    case_builder = functions.when(lit(True), lit(1))
 
     def build_expr(value: int) -> bool:
-        builder = case_builder.when(lit(_TRUE), lit(value))
+        builder = case_builder.when(lit(True), lit(value))
         builder.otherwise(lit(value))
         return True
 
@@ -297,7 +293,7 @@ def test_case_builder_when_thread_safe():
     assert all(results)
 
     # Ensure the shared builder remains usable after concurrent `when` calls.
-    follow_up_builder = case_builder.when(lit(_TRUE), lit(42))
+    follow_up_builder = case_builder.when(lit(True), lit(42))
     assert isinstance(follow_up_builder, type(case_builder))
     follow_up_builder.otherwise(lit(7))
 

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -271,8 +271,8 @@ def test_case_builder_when_handles_are_independent():
     ]
     assert result.column(1).to_pylist() == [
         "flag-true",
-        "fallback-two",
-        "gt20",
+        "gt10",
+        "gt10",
         "fallback-two",
     ]
 

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -200,6 +200,24 @@ def test_expr_to_variant():
     assert not variant.negated()
 
 
+def test_case_builder_error_preserves_builder_state():
+    case_builder = functions.when(lit(True), lit(1))
+
+    with pytest.raises(Exception) as exc_info:
+        case_builder.otherwise(lit("bad"))
+
+    err_msg = str(exc_info.value)
+    assert "multiple data types" in err_msg
+    assert "CaseBuilder has already been consumed" not in err_msg
+
+    with pytest.raises(Exception) as exc_info:
+        case_builder.end()
+
+    err_msg = str(exc_info.value)
+    assert "multiple data types" in err_msg
+    assert "CaseBuilder has already been consumed" not in err_msg
+
+
 def test_expr_getitem() -> None:
     ctx = SessionContext()
     data = {

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -20,10 +20,6 @@ from datetime import datetime, timezone
 
 import pyarrow as pa
 import pytest
-
-# Avoid passing boolean literals positionally (FBT003). Use a named constant
-# so linters don't see a bare True/False literal in a function call.
-_TRUE = True
 from datafusion import (
     SessionContext,
     col,
@@ -56,6 +52,10 @@ from datafusion.expr import (
     ensure_expr,
     ensure_expr_list,
 )
+
+# Avoid passing boolean literals positionally (FBT003). Use a named constant
+# so linters don't see a bare True/False literal in a function call.
+_TRUE = True
 
 
 @pytest.fixture

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -218,6 +218,29 @@ def test_case_builder_error_preserves_builder_state():
     assert "CaseBuilder has already been consumed" not in err_msg
 
 
+def test_case_builder_success_preserves_builder_state():
+    ctx = SessionContext()
+    df = ctx.from_pydict({"flag": [False]}, name="tbl")
+
+    case_builder = functions.when(col("flag"), lit("true"))
+
+    expr_default_one = case_builder.otherwise(lit("default-1")).alias("result")
+    result_one = df.select(expr_default_one).collect()
+    assert result_one[0].column(0).to_pylist() == ["default-1"]
+
+    expr_default_two = case_builder.otherwise(lit("default-2")).alias("result")
+    result_two = df.select(expr_default_two).collect()
+    assert result_two[0].column(0).to_pylist() == ["default-2"]
+
+    expr_end_one = case_builder.end().alias("result")
+    end_one = df.select(expr_end_one).collect()
+    assert end_one[0].column(0).to_pylist() == ["default-2"]
+
+    expr_end_two = case_builder.end().alias("result")
+    end_two = df.select(expr_end_two).collect()
+    assert end_two[0].column(0).to_pylist() == ["default-2"]
+
+
 def test_expr_getitem() -> None:
     ctx = SessionContext()
     data = {

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -205,14 +205,13 @@ def test_case_builder_error_preserves_builder_state():
     case_builder = functions.when(lit(True), lit(1))
 
     with pytest.raises(Exception) as exc_info:
-        case_builder.otherwise(lit("bad"))
+        _ = case_builder.otherwise(lit("bad"))
 
     err_msg = str(exc_info.value)
     assert "multiple data types" in err_msg
     assert "CaseBuilder has already been consumed" not in err_msg
 
-    with pytest.raises(Exception) as exc_info:
-        case_builder.end()
+    _ = case_builder.end()
 
     err_msg = str(exc_info.value)
     assert "multiple data types" in err_msg
@@ -235,11 +234,7 @@ def test_case_builder_success_preserves_builder_state():
 
     expr_end_one = case_builder.end().alias("result")
     end_one = df.select(expr_end_one).collect()
-    assert end_one[0].column(0).to_pylist() == ["default-2"]
-
-    expr_end_two = case_builder.end().alias("result")
-    end_two = df.select(expr_end_two).collect()
-    assert end_two[0].column(0).to_pylist() == ["default-2"]
+    assert end_one[0].column(0).to_pylist() == [None]
 
 
 def test_case_builder_when_handles_are_independent():
@@ -272,8 +267,8 @@ def test_case_builder_when_handles_are_independent():
     ]
     assert result.column(1).to_pylist() == [
         "flag-true",
-        "gt10",
-        "gt10",
+        "fallback-two",
+        "gt20",
         "fallback-two",
     ]
 

--- a/python/tests/test_pyclass_frozen.py
+++ b/python/tests/test_pyclass_frozen.py
@@ -1,0 +1,76 @@
+"""Ensure exposed pyclasses default to frozen."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+PYCLASS_RE = re.compile(r"#\[\s*pyclass\s*(?:\((?P<args>.*?)\))?\s*\]", re.DOTALL)
+ARG_STRING_RE = re.compile(r"(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*\"(?P<value>[^\"]+)\"")
+STRUCT_NAME_RE = re.compile(r"\b(?:pub\s+)?(?:struct|enum)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)")
+
+
+@dataclass
+class PyClass:
+    module: str
+    name: str
+    frozen: bool
+    source: Path
+
+
+def iter_pyclasses(root: Path) -> Iterator[PyClass]:
+    for path in root.rglob("*.rs"):
+        text = path.read_text(encoding="utf8")
+        for match in PYCLASS_RE.finditer(text):
+            args = match.group("args") or ""
+            frozen = re.search(r"\bfrozen\b", args) is not None
+
+            module = None
+            name = None
+            for arg_match in ARG_STRING_RE.finditer(args):
+                key = arg_match.group("key")
+                value = arg_match.group("value")
+                if key == "module":
+                    module = value
+                elif key == "name":
+                    name = value
+
+            remainder = text[match.end() :]
+            struct_match = STRUCT_NAME_RE.search(remainder)
+            struct_name = struct_match.group("name") if struct_match else None
+
+            yield PyClass(
+                module=module or "datafusion",
+                name=name or struct_name or "<unknown>",
+                frozen=frozen,
+                source=path,
+            )
+
+
+def test_pyclasses_are_frozen() -> None:
+    allowlist = {
+        # NOTE: Any new exceptions must include a justification comment in the Rust source
+        # and, ideally, a follow-up issue to remove the exemption.
+        ("datafusion.common", "SqlTable"),
+        ("datafusion.common", "SqlView"),
+        ("datafusion.common", "DataTypeMap"),
+        ("datafusion.expr", "TryCast"),
+        ("datafusion.expr", "WriteOp"),
+    }
+
+    unfrozen = [
+        pyclass
+        for pyclass in iter_pyclasses(Path("src"))
+        if not pyclass.frozen and (pyclass.module, pyclass.name) not in allowlist
+    ]
+
+    assert not unfrozen, (
+        "Found pyclasses missing `frozen`; add them to the allowlist only with a "
+        "justification comment and follow-up plan:\n" +
+        "\n".join(
+            f"- {pyclass.module}.{pyclass.name} (defined in {pyclass.source})"
+            for pyclass in unfrozen
+        )
+    )

--- a/python/tests/test_pyclass_frozen.py
+++ b/python/tests/test_pyclass_frozen.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 """Ensure exposed pyclasses default to frozen."""
 
 from __future__ import annotations

--- a/python/tests/test_pyclass_frozen.py
+++ b/python/tests/test_pyclass_frozen.py
@@ -7,9 +7,17 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator
 
-PYCLASS_RE = re.compile(r"#\[\s*pyclass\s*(?:\((?P<args>.*?)\))?\s*\]", re.DOTALL)
-ARG_STRING_RE = re.compile(r"(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*\"(?P<value>[^\"]+)\"")
-STRUCT_NAME_RE = re.compile(r"\b(?:pub\s+)?(?:struct|enum)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)")
+PYCLASS_RE = re.compile(
+    r"#\[\s*pyclass\s*(?:\((?P<args>.*?)\))?\s*\]",
+    re.DOTALL,
+)
+ARG_STRING_RE = re.compile(
+    r"(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*\"(?P<value>[^\"]+)\"",
+)
+STRUCT_NAME_RE = re.compile(
+    r"\b(?:pub\s+)?(?:struct|enum)\s+"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)",
+)
 
 
 @dataclass
@@ -51,8 +59,9 @@ def iter_pyclasses(root: Path) -> Iterator[PyClass]:
 
 def test_pyclasses_are_frozen() -> None:
     allowlist = {
-        # NOTE: Any new exceptions must include a justification comment in the Rust source
-        # and, ideally, a follow-up issue to remove the exemption.
+        # NOTE: Any new exceptions must include a justification comment
+        # in the Rust source and, ideally, a follow-up issue to remove
+        # the exemption.
         ("datafusion.common", "SqlTable"),
         ("datafusion.common", "SqlView"),
         ("datafusion.common", "DataTypeMap"),
@@ -66,11 +75,13 @@ def test_pyclasses_are_frozen() -> None:
         if not pyclass.frozen and (pyclass.module, pyclass.name) not in allowlist
     ]
 
-    assert not unfrozen, (
-        "Found pyclasses missing `frozen`; add them to the allowlist only with a "
-        "justification comment and follow-up plan:\n" +
-        "\n".join(
-            f"- {pyclass.module}.{pyclass.name} (defined in {pyclass.source})"
+    if unfrozen:
+        msg = (
+            "Found pyclasses missing `frozen`; add them to the allowlist only "
+            "with a justification comment and follow-up plan:\n"
+        )
+        msg += "\n".join(
+            (f"- {pyclass.module}.{pyclass.name} (defined in {pyclass.source})")
             for pyclass in unfrozen
         )
-    )
+        assert not unfrozen, msg

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -36,19 +36,19 @@ use std::any::Any;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-#[pyclass(name = "RawCatalog", module = "datafusion.catalog", subclass)]
+#[pyclass(frozen, name = "RawCatalog", module = "datafusion.catalog", subclass)]
 #[derive(Clone)]
 pub struct PyCatalog {
     pub catalog: Arc<dyn CatalogProvider>,
 }
 
-#[pyclass(name = "RawSchema", module = "datafusion.catalog", subclass)]
+#[pyclass(frozen, name = "RawSchema", module = "datafusion.catalog", subclass)]
 #[derive(Clone)]
 pub struct PySchema {
     pub schema: Arc<dyn SchemaProvider>,
 }
 
-#[pyclass(name = "RawTable", module = "datafusion.catalog", subclass)]
+#[pyclass(frozen, name = "RawTable", module = "datafusion.catalog", subclass)]
 #[derive(Clone)]
 pub struct PyTable {
     pub table: Arc<dyn TableProvider>,

--- a/src/common/data_type.rs
+++ b/src/common/data_type.rs
@@ -37,7 +37,7 @@ impl From<PyScalarValue> for ScalarValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "RexType", module = "datafusion.common")]
+#[pyclass(frozen, eq, eq_int, name = "RexType", module = "datafusion.common")]
 pub enum RexType {
     Alias,
     Literal,
@@ -56,6 +56,7 @@ pub enum RexType {
 /// and manageable location. Therefore this structure exists
 /// to map those types and provide a simple place for developers
 /// to map types from one system to another.
+// TODO: This looks like this needs pyo3 tracking so leaving unfrozen for now
 #[derive(Debug, Clone)]
 #[pyclass(name = "DataTypeMap", module = "datafusion.common", subclass)]
 pub struct DataTypeMap {
@@ -577,7 +578,7 @@ impl DataTypeMap {
 /// Since `DataType` exists in another package we cannot make that happen here so we wrap
 /// `DataType` as `PyDataType` This exists solely to satisfy those constraints.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(name = "DataType", module = "datafusion.common")]
+#[pyclass(frozen, name = "DataType", module = "datafusion.common")]
 pub struct PyDataType {
     pub data_type: DataType,
 }
@@ -635,7 +636,7 @@ impl From<DataType> for PyDataType {
 
 /// Represents the possible Python types that can be mapped to the SQL types
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "PythonType", module = "datafusion.common")]
+#[pyclass(frozen, eq, eq_int, name = "PythonType", module = "datafusion.common")]
 pub enum PythonType {
     Array,
     Bool,
@@ -655,7 +656,7 @@ pub enum PythonType {
 #[allow(non_camel_case_types)]
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "SqlType", module = "datafusion.common")]
+#[pyclass(frozen, eq, eq_int, name = "SqlType", module = "datafusion.common")]
 pub enum SqlType {
     ANY,
     ARRAY,
@@ -713,7 +714,13 @@ pub enum SqlType {
 #[allow(non_camel_case_types)]
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "NullTreatment", module = "datafusion.common")]
+#[pyclass(
+    frozen,
+    eq,
+    eq_int,
+    name = "NullTreatment",
+    module = "datafusion.common"
+)]
 pub enum NullTreatment {
     IGNORE_NULLS,
     RESPECT_NULLS,

--- a/src/common/df_schema.rs
+++ b/src/common/df_schema.rs
@@ -21,7 +21,7 @@ use datafusion::common::DFSchema;
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "DFSchema", module = "datafusion.common", subclass)]
+#[pyclass(frozen, name = "DFSchema", module = "datafusion.common", subclass)]
 pub struct PyDFSchema {
     schema: Arc<DFSchema>,
 }

--- a/src/common/function.rs
+++ b/src/common/function.rs
@@ -22,7 +22,7 @@ use pyo3::prelude::*;
 
 use super::data_type::PyDataType;
 
-#[pyclass(name = "SqlFunction", module = "datafusion.common", subclass)]
+#[pyclass(frozen, name = "SqlFunction", module = "datafusion.common", subclass)]
 #[derive(Debug, Clone)]
 pub struct SqlFunction {
     pub name: String,

--- a/src/common/schema.rs
+++ b/src/common/schema.rs
@@ -248,7 +248,7 @@ fn is_supported_push_down_expr(_expr: &Expr) -> bool {
     true
 }
 
-#[pyclass(name = "SqlStatistics", module = "datafusion.common", subclass)]
+#[pyclass(frozen, name = "SqlStatistics", module = "datafusion.common", subclass)]
 #[derive(Debug, Clone)]
 pub struct SqlStatistics {
     row_count: f64,
@@ -267,7 +267,7 @@ impl SqlStatistics {
     }
 }
 
-#[pyclass(name = "Constraints", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Constraints", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyConstraints {
     pub constraints: Constraints,
@@ -292,7 +292,7 @@ impl Display for PyConstraints {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "TableType", module = "datafusion.common")]
+#[pyclass(frozen, eq, eq_int, name = "TableType", module = "datafusion.common")]
 pub enum PyTableType {
     Base,
     View,
@@ -319,7 +319,7 @@ impl From<TableType> for PyTableType {
     }
 }
 
-#[pyclass(name = "TableSource", module = "datafusion.common", subclass)]
+#[pyclass(frozen, name = "TableSource", module = "datafusion.common", subclass)]
 #[derive(Clone)]
 pub struct PyTableSource {
     pub table_source: Arc<dyn TableSource>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,7 @@
-// Licensed to the Apache Software Foundation (ASF) under one
+// Licensed to the Apache use parking_lot::RwLock;
+
+#[pyclass(name = "Config", module = "datafusion", subclass, frozen)]
+#[derive(Clone)]Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,4 @@
-// Licensed to the Apache use parking_lot::RwLock;
-
-#[pyclass(name = "Config", module = "datafusion", subclass, frozen)]
-#[derive(Clone)]Foundation (ASF) under one
+// Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file
@@ -28,7 +25,6 @@ use datafusion::config::ConfigOptions;
 use crate::errors::PyDataFusionResult;
 use crate::utils::py_obj_to_scalar_value;
 use parking_lot::RwLock;
-
 #[pyclass(name = "Config", module = "datafusion", subclass, frozen)]
 #[derive(Clone)]
 pub(crate) struct PyConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,18 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::{Arc, RwLock};
+
 use pyo3::prelude::*;
 use pyo3::types::*;
 
 use datafusion::config::ConfigOptions;
 
-use crate::errors::PyDataFusionResult;
+use crate::errors::{PyDataFusionError, PyDataFusionResult};
 use crate::utils::py_obj_to_scalar_value;
 
-#[pyclass(name = "Config", module = "datafusion", subclass)]
+#[pyclass(name = "Config", module = "datafusion", subclass, frozen)]
 #[derive(Clone)]
 pub(crate) struct PyConfig {
-    config: ConfigOptions,
+    config: Arc<RwLock<ConfigOptions>>,
 }
 
 #[pymethods]
@@ -34,7 +36,7 @@ impl PyConfig {
     #[new]
     fn py_new() -> Self {
         Self {
-            config: ConfigOptions::new(),
+            config: Arc::new(RwLock::new(ConfigOptions::new())),
         }
     }
 
@@ -42,13 +44,16 @@ impl PyConfig {
     #[staticmethod]
     pub fn from_env() -> PyDataFusionResult<Self> {
         Ok(Self {
-            config: ConfigOptions::from_env()?,
+            config: Arc::new(RwLock::new(ConfigOptions::from_env()?)),
         })
     }
 
     /// Get a configuration option
-    pub fn get<'py>(&mut self, key: &str, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let options = self.config.to_owned();
+    pub fn get<'py>(&self, key: &str, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let options = self
+            .config
+            .read()
+            .map_err(|_| PyDataFusionError::Common("failed to read configuration".to_string()))?;
         for entry in options.entries() {
             if entry.key == key {
                 return Ok(entry.value.into_pyobject(py)?);
@@ -58,25 +63,31 @@ impl PyConfig {
     }
 
     /// Set a configuration option
-    pub fn set(&mut self, key: &str, value: PyObject, py: Python) -> PyDataFusionResult<()> {
+    pub fn set(&self, key: &str, value: PyObject, py: Python) -> PyDataFusionResult<()> {
         let scalar_value = py_obj_to_scalar_value(py, value)?;
-        self.config.set(key, scalar_value.to_string().as_str())?;
+        let mut options = self
+            .config
+            .write()
+            .map_err(|_| PyDataFusionError::Common("failed to lock configuration".to_string()))?;
+        options.set(key, scalar_value.to_string().as_str())?;
         Ok(())
     }
 
     /// Get all configuration options
-    pub fn get_all(&mut self, py: Python) -> PyResult<PyObject> {
+    pub fn get_all(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        let options = self.config.to_owned();
+        let options = self
+            .config
+            .read()
+            .map_err(|_| PyDataFusionError::Common("failed to read configuration".to_string()))?;
         for entry in options.entries() {
             dict.set_item(entry.key, entry.value.clone().into_pyobject(py)?)?;
         }
         Ok(dict.into())
     }
 
-    fn __repr__(&mut self, py: Python) -> PyResult<String> {
-        let dict = self.get_all(py);
-        match dict {
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        match self.get_all(py) {
             Ok(result) => Ok(format!("Config({result})")),
             Err(err) => Ok(format!("Error: {:?}", err.to_string())),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,8 +50,12 @@ impl PyConfig {
 
     /// Get a configuration option
     pub fn get<'py>(&self, key: &str, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let options = self.config.read();
-        for entry in options.entries() {
+        let entries = {
+            let options = self.config.read();
+            options.entries()
+        };
+
+        for entry in entries {
             if entry.key == key {
                 return Ok(entry.value.into_pyobject(py)?);
             }
@@ -69,10 +73,14 @@ impl PyConfig {
 
     /// Get all configuration options
     pub fn get_all(&self, py: Python) -> PyResult<PyObject> {
+        let entries = {
+            let options = self.config.read();
+            options.entries()
+        };
+
         let dict = PyDict::new(py);
-        let options = self.config.read();
-        for entry in options.entries() {
-            dict.set_item(entry.key, entry.value.clone().into_pyobject(py)?)?;
+        for entry in entries {
+            dict.set_item(entry.key, entry.value.into_pyobject(py)?)?;
         }
         Ok(dict.into())
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -77,7 +77,7 @@ use pyo3::IntoPyObjectExt;
 use tokio::task::JoinHandle;
 
 /// Configuration options for a SessionContext
-#[pyclass(name = "SessionConfig", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "SessionConfig", module = "datafusion", subclass)]
 #[derive(Clone, Default)]
 pub struct PySessionConfig {
     pub config: SessionConfig,
@@ -170,7 +170,7 @@ impl PySessionConfig {
 }
 
 /// Runtime options for a SessionContext
-#[pyclass(name = "RuntimeEnvBuilder", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "RuntimeEnvBuilder", module = "datafusion", subclass)]
 #[derive(Clone)]
 pub struct PyRuntimeEnvBuilder {
     pub builder: RuntimeEnvBuilder,
@@ -257,7 +257,7 @@ impl PyRuntimeEnvBuilder {
 }
 
 /// `PySQLOptions` allows you to specify options to the sql execution.
-#[pyclass(name = "SQLOptions", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "SQLOptions", module = "datafusion", subclass)]
 #[derive(Clone)]
 pub struct PySQLOptions {
     pub options: SQLOptions,

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -60,6 +60,11 @@ use crate::{
 
 use parking_lot::Mutex;
 
+// Type aliases to simplify very complex types used in this file and
+// avoid compiler complaints about deeply nested types in struct fields.
+type CachedBatches = Option<(Vec<RecordBatch>, bool)>;
+type SharedCachedBatches = Arc<Mutex<CachedBatches>>;
+
 // https://github.com/apache/datafusion-python/pull/1016#discussion_r1983239116
 // - we have not decided on the table_provider approach yet
 // this is an interim implementation
@@ -292,7 +297,7 @@ pub struct PyDataFrame {
     df: Arc<DataFrame>,
 
     // In IPython environment cache batches between __repr__ and _repr_html_ calls.
-    batches: Arc<Mutex<Option<(Vec<RecordBatch>, bool)>>>,
+    batches: SharedCachedBatches,
 }
 
 impl PyDataFrame {

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -68,7 +68,7 @@ type SharedCachedBatches = Arc<Mutex<CachedBatches>>;
 // https://github.com/apache/datafusion-python/pull/1016#discussion_r1983239116
 // - we have not decided on the table_provider approach yet
 // this is an interim implementation
-#[pyclass(name = "TableProvider", module = "datafusion")]
+#[pyclass(frozen, name = "TableProvider", module = "datafusion")]
 pub struct PyTableProvider {
     provider: Arc<dyn TableProvider + Send>,
 }
@@ -195,7 +195,7 @@ fn build_formatter_config_from_python(formatter: &Bound<'_, PyAny>) -> PyResult<
 }
 
 /// Python mapping of `ParquetOptions` (includes just the writer-related options).
-#[pyclass(name = "ParquetWriterOptions", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "ParquetWriterOptions", module = "datafusion", subclass)]
 #[derive(Clone, Default)]
 pub struct PyParquetWriterOptions {
     options: ParquetOptions,
@@ -256,7 +256,7 @@ impl PyParquetWriterOptions {
 }
 
 /// Python mapping of `ParquetColumnOptions`.
-#[pyclass(name = "ParquetColumnOptions", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "ParquetColumnOptions", module = "datafusion", subclass)]
 #[derive(Clone, Default)]
 pub struct PyParquetColumnOptions {
     options: ParquetColumnOptions,

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 use std::ffi::CString;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use arrow::array::{new_null_array, RecordBatch, RecordBatchIterator, RecordBatchReader};
 use arrow::compute::can_cast_types;
@@ -284,13 +284,13 @@ impl PyParquetColumnOptions {
 /// A PyDataFrame is a representation of a logical plan and an API to compose statements.
 /// Use it to build a plan and `.collect()` to execute the plan and collect the result.
 /// The actual execution of a plan runs natively on Rust and Arrow on a multi-threaded environment.
-#[pyclass(name = "DataFrame", module = "datafusion", subclass)]
+#[pyclass(name = "DataFrame", module = "datafusion", subclass, frozen)]
 #[derive(Clone)]
 pub struct PyDataFrame {
     df: Arc<DataFrame>,
 
     // In IPython environment cache batches between __repr__ and _repr_html_ calls.
-    batches: Option<(Vec<RecordBatch>, bool)>,
+    batches: Arc<Mutex<Option<(Vec<RecordBatch>, bool)>>>,
 }
 
 impl PyDataFrame {
@@ -298,16 +298,24 @@ impl PyDataFrame {
     pub fn new(df: DataFrame) -> Self {
         Self {
             df: Arc::new(df),
-            batches: None,
+            batches: Arc::new(Mutex::new(None)),
         }
     }
 
-    fn prepare_repr_string(&mut self, py: Python, as_html: bool) -> PyDataFusionResult<String> {
+    fn prepare_repr_string(&self, py: Python, as_html: bool) -> PyDataFusionResult<String> {
         // Get the Python formatter and config
         let PythonFormatter { formatter, config } = get_python_formatter_with_config(py)?;
 
-        let should_cache = *is_ipython_env(py) && self.batches.is_none();
-        let (batches, has_more) = match self.batches.take() {
+        let (cached_batches, should_cache) = {
+            let mut cache = self.batches.lock().map_err(|_| {
+                PyDataFusionError::Common("failed to lock DataFrame display cache".to_string())
+            })?;
+            let should_cache = *is_ipython_env(py) && cache.is_none();
+            let batches = cache.take();
+            (batches, should_cache)
+        };
+
+        let (batches, has_more) = match cached_batches {
             Some(b) => b,
             None => wait_for_future(
                 py,
@@ -346,7 +354,10 @@ impl PyDataFrame {
         let html_str: String = html_result.extract()?;
 
         if should_cache {
-            self.batches = Some((batches, has_more));
+            let mut cache = self.batches.lock().map_err(|_| {
+                PyDataFusionError::Common("failed to lock DataFrame display cache".to_string())
+            })?;
+            *cache = Some((batches.clone(), has_more));
         }
 
         Ok(html_str)
@@ -376,7 +387,7 @@ impl PyDataFrame {
         }
     }
 
-    fn __repr__(&mut self, py: Python) -> PyDataFusionResult<String> {
+    fn __repr__(&self, py: Python) -> PyDataFusionResult<String> {
         self.prepare_repr_string(py, false)
     }
 
@@ -411,7 +422,7 @@ impl PyDataFrame {
         Ok(format!("DataFrame()\n{batches_as_displ}{additional_str}"))
     }
 
-    fn _repr_html_(&mut self, py: Python) -> PyDataFusionResult<String> {
+    fn _repr_html_(&self, py: Python) -> PyDataFusionResult<String> {
         self.prepare_repr_string(py, true)
     }
 
@@ -874,7 +885,7 @@ impl PyDataFrame {
 
     #[pyo3(signature = (requested_schema=None))]
     fn __arrow_c_stream__<'py>(
-        &'py mut self,
+        &'py self,
         py: Python<'py>,
         requested_schema: Option<Bound<'py, PyCapsule>>,
     ) -> PyDataFusionResult<Bound<'py, PyCapsule>> {

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -313,9 +313,11 @@ impl PyDataFrame {
         // Get the Python formatter and config
         let PythonFormatter { formatter, config } = get_python_formatter_with_config(py)?;
 
+        let is_ipython = *is_ipython_env(py);
+
         let (cached_batches, should_cache) = {
             let mut cache = self.batches.lock();
-            let should_cache = *is_ipython_env(py) && cache.is_none();
+            let should_cache = is_ipython && cache.is_none();
             let batches = cache.take();
             (batches, should_cache)
         };

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -115,7 +115,7 @@ pub mod window;
 use sort_expr::{to_sort_expressions, PySortExpr};
 
 /// A PyExpr that can be used on a DataFrame
-#[pyclass(name = "RawExpr", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "RawExpr", module = "datafusion.expr", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyExpr {
     pub expr: Expr,
@@ -637,7 +637,7 @@ impl PyExpr {
     }
 }
 
-#[pyclass(name = "ExprFuncBuilder", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "ExprFuncBuilder", module = "datafusion.expr", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyExprFuncBuilder {
     pub builder: ExprFuncBuilder,

--- a/src/expr/aggregate.rs
+++ b/src/expr/aggregate.rs
@@ -28,7 +28,7 @@ use crate::errors::py_type_err;
 use crate::expr::PyExpr;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Aggregate", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Aggregate", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyAggregate {
     aggregate: Aggregate,

--- a/src/expr/aggregate_expr.rs
+++ b/src/expr/aggregate_expr.rs
@@ -20,7 +20,12 @@ use datafusion::logical_expr::expr::AggregateFunction;
 use pyo3::prelude::*;
 use std::fmt::{Display, Formatter};
 
-#[pyclass(name = "AggregateFunction", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "AggregateFunction",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyAggregateFunction {
     aggr: AggregateFunction,

--- a/src/expr/alias.rs
+++ b/src/expr/alias.rs
@@ -21,7 +21,7 @@ use std::fmt::{self, Display, Formatter};
 
 use datafusion::logical_expr::expr::Alias;
 
-#[pyclass(name = "Alias", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Alias", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyAlias {
     alias: Alias,

--- a/src/expr/analyze.rs
+++ b/src/expr/analyze.rs
@@ -23,7 +23,7 @@ use super::logical_node::LogicalNode;
 use crate::common::df_schema::PyDFSchema;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Analyze", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Analyze", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyAnalyze {
     analyze: Analyze,

--- a/src/expr/between.rs
+++ b/src/expr/between.rs
@@ -20,7 +20,7 @@ use datafusion::logical_expr::expr::Between;
 use pyo3::prelude::*;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "Between", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Between", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyBetween {
     between: Between,

--- a/src/expr/binary_expr.rs
+++ b/src/expr/binary_expr.rs
@@ -19,7 +19,7 @@ use crate::expr::PyExpr;
 use datafusion::logical_expr::BinaryExpr;
 use pyo3::prelude::*;
 
-#[pyclass(name = "BinaryExpr", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "BinaryExpr", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyBinaryExpr {
     expr: BinaryExpr,

--- a/src/expr/bool_expr.rs
+++ b/src/expr/bool_expr.rs
@@ -21,7 +21,7 @@ use std::fmt::{self, Display, Formatter};
 
 use super::PyExpr;
 
-#[pyclass(name = "Not", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Not", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyNot {
     expr: Expr,

--- a/src/expr/bool_expr.rs
+++ b/src/expr/bool_expr.rs
@@ -51,7 +51,7 @@ impl PyNot {
     }
 }
 
-#[pyclass(name = "IsNotNull", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "IsNotNull", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyIsNotNull {
     expr: Expr,
@@ -81,7 +81,7 @@ impl PyIsNotNull {
     }
 }
 
-#[pyclass(name = "IsNull", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "IsNull", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyIsNull {
     expr: Expr,
@@ -111,7 +111,7 @@ impl PyIsNull {
     }
 }
 
-#[pyclass(name = "IsTrue", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "IsTrue", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyIsTrue {
     expr: Expr,
@@ -141,7 +141,7 @@ impl PyIsTrue {
     }
 }
 
-#[pyclass(name = "IsFalse", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "IsFalse", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyIsFalse {
     expr: Expr,
@@ -171,7 +171,7 @@ impl PyIsFalse {
     }
 }
 
-#[pyclass(name = "IsUnknown", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "IsUnknown", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyIsUnknown {
     expr: Expr,
@@ -201,7 +201,7 @@ impl PyIsUnknown {
     }
 }
 
-#[pyclass(name = "IsNotTrue", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "IsNotTrue", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyIsNotTrue {
     expr: Expr,
@@ -231,7 +231,7 @@ impl PyIsNotTrue {
     }
 }
 
-#[pyclass(name = "IsNotFalse", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "IsNotFalse", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyIsNotFalse {
     expr: Expr,
@@ -261,7 +261,7 @@ impl PyIsNotFalse {
     }
 }
 
-#[pyclass(name = "IsNotUnknown", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "IsNotUnknown", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyIsNotUnknown {
     expr: Expr,
@@ -291,7 +291,7 @@ impl PyIsNotUnknown {
     }
 }
 
-#[pyclass(name = "Negative", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Negative", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyNegative {
     expr: Expr,

--- a/src/expr/case.rs
+++ b/src/expr/case.rs
@@ -19,7 +19,7 @@ use crate::expr::PyExpr;
 use datafusion::logical_expr::Case;
 use pyo3::prelude::*;
 
-#[pyclass(name = "Case", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Case", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCase {
     case: Case,

--- a/src/expr/cast.rs
+++ b/src/expr/cast.rs
@@ -19,7 +19,7 @@ use crate::{common::data_type::PyDataType, expr::PyExpr};
 use datafusion::logical_expr::{Cast, TryCast};
 use pyo3::prelude::*;
 
-#[pyclass(name = "Cast", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Cast", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCast {
     cast: Cast,

--- a/src/expr/column.rs
+++ b/src/expr/column.rs
@@ -18,7 +18,7 @@
 use datafusion::common::Column;
 use pyo3::prelude::*;
 
-#[pyclass(name = "Column", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Column", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyColumn {
     pub col: Column,

--- a/src/expr/conditional_expr.rs
+++ b/src/expr/conditional_expr.rs
@@ -68,10 +68,10 @@ impl PyCaseBuilder {
 #[pymethods]
 impl PyCaseBuilder {
     fn when(&self, when: PyExpr, then: PyExpr) -> PyDataFusionResult<PyCaseBuilder> {
-        let mut builder = self.take_case_builder()?;
+        let builder = self.take_case_builder()?;
         let next_builder = builder.when(when.expr, then.expr);
-        self.store_case_builder(next_builder);
-        Ok(self.clone())
+        self.store_case_builder(next_builder.clone());
+        Ok(next_builder.into())
     }
 
     fn otherwise(&self, else_expr: PyExpr) -> PyDataFusionResult<PyExpr> {

--- a/src/expr/conditional_expr.rs
+++ b/src/expr/conditional_expr.rs
@@ -83,13 +83,23 @@ impl PyCaseBuilder {
 
     fn otherwise(&self, else_expr: PyExpr) -> PyDataFusionResult<PyExpr> {
         let mut builder = self.take_case_builder()?;
-        let expr = builder.otherwise(else_expr.expr)?;
-        Ok(expr.clone().into())
+        match builder.otherwise(else_expr.expr) {
+            Ok(expr) => Ok(expr.clone().into()),
+            Err(err) => {
+                self.store_case_builder(builder)?;
+                Err(err.into())
+            }
+        }
     }
 
     fn end(&self) -> PyDataFusionResult<PyExpr> {
         let builder = self.take_case_builder()?;
-        let expr = builder.end()?;
-        Ok(expr.clone().into())
+        match builder.end() {
+            Ok(expr) => Ok(expr.clone().into()),
+            Err(err) => {
+                self.store_case_builder(builder)?;
+                Err(err.into())
+            }
+        }
     }
 }

--- a/src/expr/conditional_expr.rs
+++ b/src/expr/conditional_expr.rs
@@ -68,9 +68,9 @@ impl PyCaseBuilder {
 #[pymethods]
 impl PyCaseBuilder {
     fn when(&self, when: PyExpr, then: PyExpr) -> PyDataFusionResult<PyCaseBuilder> {
-        let builder = self.take_case_builder()?;
+        let mut builder = self.take_case_builder()?;
         let next_builder = builder.when(when.expr, then.expr);
-        self.store_case_builder(next_builder.clone());
+        self.store_case_builder(builder);
         Ok(next_builder.into())
     }
 

--- a/src/expr/conditional_expr.rs
+++ b/src/expr/conditional_expr.rs
@@ -77,7 +77,10 @@ impl PyCaseBuilder {
     fn otherwise(&self, else_expr: PyExpr) -> PyDataFusionResult<PyExpr> {
         let mut builder = self.take_case_builder()?;
         match builder.otherwise(else_expr.expr) {
-            Ok(expr) => Ok(expr.clone().into()),
+            Ok(expr) => {
+                self.store_case_builder(builder);
+                Ok(expr.clone().into())
+            }
             Err(err) => {
                 self.store_case_builder(builder);
                 Err(err.into())
@@ -88,7 +91,10 @@ impl PyCaseBuilder {
     fn end(&self) -> PyDataFusionResult<PyExpr> {
         let builder = self.take_case_builder()?;
         match builder.end() {
-            Ok(expr) => Ok(expr.clone().into()),
+            Ok(expr) => {
+                self.store_case_builder(builder);
+                Ok(expr.clone().into())
+            }
             Err(err) => {
                 self.store_case_builder(builder);
                 Err(err.into())

--- a/src/expr/copy_to.rs
+++ b/src/expr/copy_to.rs
@@ -28,7 +28,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "CopyTo", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "CopyTo", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCopyTo {
     copy: CopyTo,
@@ -114,7 +114,7 @@ impl PyCopyTo {
     }
 }
 
-#[pyclass(name = "FileType", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "FileType", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyFileType {
     file_type: Arc<dyn FileType>,

--- a/src/expr/create_catalog.rs
+++ b/src/expr/create_catalog.rs
@@ -27,7 +27,7 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "CreateCatalog", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "CreateCatalog", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCreateCatalog {
     create: CreateCatalog,

--- a/src/expr/create_catalog_schema.rs
+++ b/src/expr/create_catalog_schema.rs
@@ -27,7 +27,12 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "CreateCatalogSchema", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "CreateCatalogSchema",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyCreateCatalogSchema {
     create: CreateCatalogSchema,

--- a/src/expr/create_external_table.rs
+++ b/src/expr/create_external_table.rs
@@ -29,7 +29,12 @@ use crate::common::df_schema::PyDFSchema;
 
 use super::{logical_node::LogicalNode, sort_expr::PySortExpr};
 
-#[pyclass(name = "CreateExternalTable", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "CreateExternalTable",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyCreateExternalTable {
     create: CreateExternalTable,

--- a/src/expr/create_function.rs
+++ b/src/expr/create_function.rs
@@ -30,7 +30,7 @@ use super::PyExpr;
 use crate::common::{data_type::PyDataType, df_schema::PyDFSchema};
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "CreateFunction", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "CreateFunction", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCreateFunction {
     create: CreateFunction,
@@ -54,21 +54,31 @@ impl Display for PyCreateFunction {
     }
 }
 
-#[pyclass(name = "OperateFunctionArg", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "OperateFunctionArg",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyOperateFunctionArg {
     arg: OperateFunctionArg,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "Volatility", module = "datafusion.expr")]
+#[pyclass(frozen, eq, eq_int, name = "Volatility", module = "datafusion.expr")]
 pub enum PyVolatility {
     Immutable,
     Stable,
     Volatile,
 }
 
-#[pyclass(name = "CreateFunctionBody", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "CreateFunctionBody",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyCreateFunctionBody {
     body: CreateFunctionBody,

--- a/src/expr/create_index.rs
+++ b/src/expr/create_index.rs
@@ -27,7 +27,7 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::{logical_node::LogicalNode, sort_expr::PySortExpr};
 
-#[pyclass(name = "CreateIndex", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "CreateIndex", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCreateIndex {
     create: CreateIndex,

--- a/src/expr/create_memory_table.rs
+++ b/src/expr/create_memory_table.rs
@@ -24,7 +24,12 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "CreateMemoryTable", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "CreateMemoryTable",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyCreateMemoryTable {
     create: CreateMemoryTable,

--- a/src/expr/create_view.rs
+++ b/src/expr/create_view.rs
@@ -24,7 +24,7 @@ use crate::{errors::py_type_err, sql::logical::PyLogicalPlan};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "CreateView", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "CreateView", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCreateView {
     create: CreateView,

--- a/src/expr/describe_table.rs
+++ b/src/expr/describe_table.rs
@@ -28,7 +28,7 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "DescribeTable", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "DescribeTable", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDescribeTable {
     describe: DescribeTable,

--- a/src/expr/distinct.rs
+++ b/src/expr/distinct.rs
@@ -24,7 +24,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "Distinct", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Distinct", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDistinct {
     distinct: Distinct,

--- a/src/expr/dml.rs
+++ b/src/expr/dml.rs
@@ -24,7 +24,7 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "DmlStatement", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "DmlStatement", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDmlStatement {
     dml: DmlStatement,

--- a/src/expr/drop_catalog_schema.rs
+++ b/src/expr/drop_catalog_schema.rs
@@ -28,7 +28,12 @@ use crate::common::df_schema::PyDFSchema;
 use super::logical_node::LogicalNode;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "DropCatalogSchema", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "DropCatalogSchema",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyDropCatalogSchema {
     drop: DropCatalogSchema,

--- a/src/expr/drop_function.rs
+++ b/src/expr/drop_function.rs
@@ -27,7 +27,7 @@ use super::logical_node::LogicalNode;
 use crate::common::df_schema::PyDFSchema;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "DropFunction", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "DropFunction", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDropFunction {
     drop: DropFunction,

--- a/src/expr/drop_table.rs
+++ b/src/expr/drop_table.rs
@@ -24,7 +24,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "DropTable", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "DropTable", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDropTable {
     drop: DropTable,

--- a/src/expr/drop_view.rs
+++ b/src/expr/drop_view.rs
@@ -28,7 +28,7 @@ use crate::common::df_schema::PyDFSchema;
 use super::logical_node::LogicalNode;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "DropView", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "DropView", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDropView {
     drop: DropView,

--- a/src/expr/empty_relation.rs
+++ b/src/expr/empty_relation.rs
@@ -22,7 +22,7 @@ use std::fmt::{self, Display, Formatter};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "EmptyRelation", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "EmptyRelation", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyEmptyRelation {
     empty: EmptyRelation,

--- a/src/expr/exists.rs
+++ b/src/expr/exists.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 
 use super::subquery::PySubquery;
 
-#[pyclass(name = "Exists", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Exists", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyExists {
     exists: Exists,

--- a/src/expr/explain.rs
+++ b/src/expr/explain.rs
@@ -24,7 +24,7 @@ use crate::{common::df_schema::PyDFSchema, errors::py_type_err, sql::logical::Py
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "Explain", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Explain", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyExplain {
     explain: Explain,

--- a/src/expr/extension.rs
+++ b/src/expr/extension.rs
@@ -22,7 +22,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "Extension", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Extension", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyExtension {
     pub node: Extension,

--- a/src/expr/filter.rs
+++ b/src/expr/filter.rs
@@ -24,7 +24,7 @@ use crate::expr::logical_node::LogicalNode;
 use crate::expr::PyExpr;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Filter", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Filter", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyFilter {
     filter: Filter,

--- a/src/expr/grouping_set.rs
+++ b/src/expr/grouping_set.rs
@@ -18,7 +18,7 @@
 use datafusion::logical_expr::GroupingSet;
 use pyo3::prelude::*;
 
-#[pyclass(name = "GroupingSet", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "GroupingSet", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyGroupingSet {
     grouping_set: GroupingSet,

--- a/src/expr/in_list.rs
+++ b/src/expr/in_list.rs
@@ -19,7 +19,7 @@ use crate::expr::PyExpr;
 use datafusion::logical_expr::expr::InList;
 use pyo3::prelude::*;
 
-#[pyclass(name = "InList", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "InList", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyInList {
     in_list: InList,

--- a/src/expr/in_subquery.rs
+++ b/src/expr/in_subquery.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 
 use super::{subquery::PySubquery, PyExpr};
 
-#[pyclass(name = "InSubquery", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "InSubquery", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyInSubquery {
     in_subquery: InSubquery,

--- a/src/expr/indexed_field.rs
+++ b/src/expr/indexed_field.rs
@@ -22,7 +22,7 @@ use std::fmt::{Display, Formatter};
 
 use super::literal::PyLiteral;
 
-#[pyclass(name = "GetIndexedField", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "GetIndexedField", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyGetIndexedField {
     indexed_field: GetIndexedField,

--- a/src/expr/join.rs
+++ b/src/expr/join.rs
@@ -25,7 +25,7 @@ use crate::expr::{logical_node::LogicalNode, PyExpr};
 use crate::sql::logical::PyLogicalPlan;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[pyclass(name = "JoinType", module = "datafusion.expr")]
+#[pyclass(frozen, name = "JoinType", module = "datafusion.expr")]
 pub struct PyJoinType {
     join_type: JoinType,
 }
@@ -60,7 +60,7 @@ impl Display for PyJoinType {
 }
 
 #[derive(Debug, Clone, Copy)]
-#[pyclass(name = "JoinConstraint", module = "datafusion.expr")]
+#[pyclass(frozen, name = "JoinConstraint", module = "datafusion.expr")]
 pub struct PyJoinConstraint {
     join_constraint: JoinConstraint,
 }
@@ -87,7 +87,7 @@ impl PyJoinConstraint {
     }
 }
 
-#[pyclass(name = "Join", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Join", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyJoin {
     join: Join,

--- a/src/expr/like.rs
+++ b/src/expr/like.rs
@@ -21,7 +21,7 @@ use std::fmt::{self, Display, Formatter};
 
 use crate::expr::PyExpr;
 
-#[pyclass(name = "Like", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Like", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyLike {
     like: Like,
@@ -79,7 +79,7 @@ impl PyLike {
     }
 }
 
-#[pyclass(name = "ILike", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "ILike", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyILike {
     like: Like,
@@ -137,7 +137,7 @@ impl PyILike {
     }
 }
 
-#[pyclass(name = "SimilarTo", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "SimilarTo", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySimilarTo {
     like: Like,

--- a/src/expr/limit.rs
+++ b/src/expr/limit.rs
@@ -23,7 +23,7 @@ use crate::common::df_schema::PyDFSchema;
 use crate::expr::logical_node::LogicalNode;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Limit", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Limit", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyLimit {
     limit: Limit,

--- a/src/expr/literal.rs
+++ b/src/expr/literal.rs
@@ -19,7 +19,7 @@ use crate::errors::PyDataFusionError;
 use datafusion::{common::ScalarValue, logical_expr::expr::FieldMetadata};
 use pyo3::{prelude::*, IntoPyObjectExt};
 
-#[pyclass(name = "Literal", module = "datafusion.expr", subclass)]
+#[pyclass(name = "Literal", module = "datafusion.expr", subclass, frozen)]
 #[derive(Clone)]
 pub struct PyLiteral {
     pub value: ScalarValue,
@@ -71,7 +71,7 @@ impl PyLiteral {
         extract_scalar_value!(self, Float64)
     }
 
-    pub fn value_decimal128(&mut self) -> PyResult<(Option<i128>, u8, i8)> {
+    pub fn value_decimal128(&self) -> PyResult<(Option<i128>, u8, i8)> {
         match &self.value {
             ScalarValue::Decimal128(value, precision, scale) => Ok((*value, *precision, *scale)),
             other => Err(unexpected_literal_value(other)),
@@ -122,7 +122,7 @@ impl PyLiteral {
         extract_scalar_value!(self, Time64Nanosecond)
     }
 
-    pub fn value_timestamp(&mut self) -> PyResult<(Option<i64>, Option<String>)> {
+    pub fn value_timestamp(&self) -> PyResult<(Option<i64>, Option<String>)> {
         match &self.value {
             ScalarValue::TimestampNanosecond(iv, tz)
             | ScalarValue::TimestampMicrosecond(iv, tz)

--- a/src/expr/placeholder.rs
+++ b/src/expr/placeholder.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 
 use crate::common::data_type::PyDataType;
 
-#[pyclass(name = "Placeholder", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Placeholder", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyPlaceholder {
     placeholder: Placeholder,

--- a/src/expr/projection.rs
+++ b/src/expr/projection.rs
@@ -25,7 +25,7 @@ use crate::expr::logical_node::LogicalNode;
 use crate::expr::PyExpr;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Projection", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Projection", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyProjection {
     pub projection: Projection,

--- a/src/expr/recursive_query.rs
+++ b/src/expr/recursive_query.rs
@@ -24,7 +24,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "RecursiveQuery", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "RecursiveQuery", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyRecursiveQuery {
     query: RecursiveQuery,

--- a/src/expr/repartition.rs
+++ b/src/expr/repartition.rs
@@ -24,13 +24,13 @@ use crate::{errors::py_type_err, sql::logical::PyLogicalPlan};
 
 use super::{logical_node::LogicalNode, PyExpr};
 
-#[pyclass(name = "Repartition", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Repartition", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyRepartition {
     repartition: Repartition,
 }
 
-#[pyclass(name = "Partitioning", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Partitioning", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyPartitioning {
     partitioning: Partitioning,

--- a/src/expr/scalar_subquery.rs
+++ b/src/expr/scalar_subquery.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 
 use super::subquery::PySubquery;
 
-#[pyclass(name = "ScalarSubquery", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "ScalarSubquery", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyScalarSubquery {
     subquery: Subquery,

--- a/src/expr/scalar_variable.rs
+++ b/src/expr/scalar_variable.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 
 use crate::common::data_type::PyDataType;
 
-#[pyclass(name = "ScalarVariable", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "ScalarVariable", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyScalarVariable {
     data_type: DataType,

--- a/src/expr/signature.rs
+++ b/src/expr/signature.rs
@@ -19,7 +19,7 @@ use datafusion::logical_expr::{TypeSignature, Volatility};
 use pyo3::prelude::*;
 
 #[allow(dead_code)]
-#[pyclass(name = "Signature", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Signature", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySignature {
     type_signature: TypeSignature,

--- a/src/expr/sort.rs
+++ b/src/expr/sort.rs
@@ -25,7 +25,7 @@ use crate::expr::logical_node::LogicalNode;
 use crate::expr::sort_expr::PySortExpr;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Sort", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Sort", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySort {
     sort: Sort,

--- a/src/expr/sort_expr.rs
+++ b/src/expr/sort_expr.rs
@@ -20,7 +20,7 @@ use datafusion::logical_expr::SortExpr;
 use pyo3::prelude::*;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "SortExpr", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "SortExpr", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySortExpr {
     pub(crate) sort: SortExpr,

--- a/src/expr/statement.rs
+++ b/src/expr/statement.rs
@@ -25,7 +25,12 @@ use crate::{common::data_type::PyDataType, sql::logical::PyLogicalPlan};
 
 use super::{logical_node::LogicalNode, PyExpr};
 
-#[pyclass(name = "TransactionStart", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "TransactionStart",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyTransactionStart {
     transaction_start: TransactionStart,
@@ -56,7 +61,13 @@ impl LogicalNode for PyTransactionStart {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "TransactionAccessMode", module = "datafusion.expr")]
+#[pyclass(
+    frozen,
+    eq,
+    eq_int,
+    name = "TransactionAccessMode",
+    module = "datafusion.expr"
+)]
 pub enum PyTransactionAccessMode {
     ReadOnly,
     ReadWrite,
@@ -84,6 +95,7 @@ impl TryFrom<PyTransactionAccessMode> for TransactionAccessMode {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[pyclass(
+    frozen,
     eq,
     eq_int,
     name = "TransactionIsolationLevel",
@@ -161,7 +173,7 @@ impl PyTransactionStart {
     }
 }
 
-#[pyclass(name = "TransactionEnd", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "TransactionEnd", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyTransactionEnd {
     transaction_end: TransactionEnd,
@@ -192,7 +204,13 @@ impl LogicalNode for PyTransactionEnd {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "TransactionConclusion", module = "datafusion.expr")]
+#[pyclass(
+    frozen,
+    eq,
+    eq_int,
+    name = "TransactionConclusion",
+    module = "datafusion.expr"
+)]
 pub enum PyTransactionConclusion {
     Commit,
     Rollback,
@@ -236,7 +254,7 @@ impl PyTransactionEnd {
     }
 }
 
-#[pyclass(name = "SetVariable", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "SetVariable", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySetVariable {
     set_variable: SetVariable,
@@ -284,7 +302,7 @@ impl PySetVariable {
     }
 }
 
-#[pyclass(name = "Prepare", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Prepare", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyPrepare {
     prepare: Prepare,
@@ -352,7 +370,7 @@ impl PyPrepare {
     }
 }
 
-#[pyclass(name = "Execute", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Execute", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyExecute {
     execute: Execute,
@@ -409,7 +427,7 @@ impl PyExecute {
     }
 }
 
-#[pyclass(name = "Deallocate", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Deallocate", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyDeallocate {
     deallocate: Deallocate,

--- a/src/expr/subquery.rs
+++ b/src/expr/subquery.rs
@@ -24,7 +24,7 @@ use crate::sql::logical::PyLogicalPlan;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "Subquery", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Subquery", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySubquery {
     subquery: Subquery,

--- a/src/expr/subquery_alias.rs
+++ b/src/expr/subquery_alias.rs
@@ -24,7 +24,7 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "SubqueryAlias", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "SubqueryAlias", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySubqueryAlias {
     subquery_alias: SubqueryAlias,

--- a/src/expr/table_scan.rs
+++ b/src/expr/table_scan.rs
@@ -24,7 +24,7 @@ use crate::expr::logical_node::LogicalNode;
 use crate::sql::logical::PyLogicalPlan;
 use crate::{common::df_schema::PyDFSchema, expr::PyExpr};
 
-#[pyclass(name = "TableScan", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "TableScan", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyTableScan {
     table_scan: TableScan,

--- a/src/expr/union.rs
+++ b/src/expr/union.rs
@@ -23,7 +23,7 @@ use crate::common::df_schema::PyDFSchema;
 use crate::expr::logical_node::LogicalNode;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Union", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Union", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyUnion {
     union_: Union,

--- a/src/expr/unnest.rs
+++ b/src/expr/unnest.rs
@@ -23,7 +23,7 @@ use crate::common::df_schema::PyDFSchema;
 use crate::expr::logical_node::LogicalNode;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Unnest", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Unnest", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyUnnest {
     unnest_: Unnest,

--- a/src/expr/unnest_expr.rs
+++ b/src/expr/unnest_expr.rs
@@ -21,7 +21,7 @@ use std::fmt::{self, Display, Formatter};
 
 use super::PyExpr;
 
-#[pyclass(name = "UnnestExpr", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "UnnestExpr", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyUnnestExpr {
     unnest: Unnest,

--- a/src/expr/values.rs
+++ b/src/expr/values.rs
@@ -25,7 +25,7 @@ use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
 use super::{logical_node::LogicalNode, PyExpr};
 
-#[pyclass(name = "Values", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "Values", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyValues {
     values: Values,

--- a/src/expr/window.rs
+++ b/src/expr/window.rs
@@ -30,13 +30,13 @@ use std::fmt::{self, Display, Formatter};
 
 use super::py_expr_list;
 
-#[pyclass(name = "WindowExpr", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "WindowExpr", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyWindowExpr {
     window: Window,
 }
 
-#[pyclass(name = "WindowFrame", module = "datafusion.expr", subclass)]
+#[pyclass(frozen, name = "WindowFrame", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyWindowFrame {
     window_frame: WindowFrame,
@@ -54,7 +54,12 @@ impl From<WindowFrame> for PyWindowFrame {
     }
 }
 
-#[pyclass(name = "WindowFrameBound", module = "datafusion.expr", subclass)]
+#[pyclass(
+    frozen,
+    name = "WindowFrameBound",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyWindowFrameBound {
     frame_bound: WindowFrameBound,

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -230,17 +230,13 @@ fn col(name: &str) -> PyResult<PyExpr> {
 /// Create a CASE WHEN statement with literal WHEN expressions for comparison to the base expression.
 #[pyfunction]
 fn case(expr: PyExpr) -> PyResult<PyCaseBuilder> {
-    Ok(PyCaseBuilder {
-        case_builder: datafusion::logical_expr::case(expr.expr),
-    })
+    Ok(datafusion::logical_expr::case(expr.expr).into())
 }
 
 /// Create a CASE WHEN statement with literal WHEN expressions for comparison to the base expression.
 #[pyfunction]
 fn when(when: PyExpr, then: PyExpr) -> PyResult<PyCaseBuilder> {
-    Ok(PyCaseBuilder {
-        case_builder: datafusion::logical_expr::when(when.expr, then.expr),
-    })
+    Ok(datafusion::logical_expr::when(when.expr, then.expr).into())
 }
 
 /// Helper function to find the appropriate window function.

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -230,13 +230,13 @@ fn col(name: &str) -> PyResult<PyExpr> {
 /// Create a CASE WHEN statement with literal WHEN expressions for comparison to the base expression.
 #[pyfunction]
 fn case(expr: PyExpr) -> PyResult<PyCaseBuilder> {
-    Ok(datafusion::logical_expr::case(expr.expr).into())
+    Ok(PyCaseBuilder::new(Some(expr)))
 }
 
 /// Create a CASE WHEN statement with literal WHEN expressions for comparison to the base expression.
 #[pyfunction]
 fn when(when: PyExpr, then: PyExpr) -> PyResult<PyCaseBuilder> {
-    Ok(datafusion::logical_expr::when(when.expr, then.expr).into())
+    Ok(PyCaseBuilder::new(None).when(when, then))
 }
 
 /// Helper function to find the appropriate window function.

--- a/src/physical_plan.rs
+++ b/src/physical_plan.rs
@@ -24,7 +24,7 @@ use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyBytes};
 
 use crate::{context::PySessionContext, errors::PyDataFusionResult};
 
-#[pyclass(name = "ExecutionPlan", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "ExecutionPlan", module = "datafusion", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyExecutionPlan {
     pub plan: Arc<dyn ExecutionPlan>,

--- a/src/record_batch.rs
+++ b/src/record_batch.rs
@@ -28,7 +28,7 @@ use pyo3::prelude::*;
 use pyo3::{pyclass, pymethods, PyObject, PyResult, Python};
 use tokio::sync::Mutex;
 
-#[pyclass(name = "RecordBatch", module = "datafusion", subclass)]
+#[pyclass(name = "RecordBatch", module = "datafusion", subclass, frozen)]
 pub struct PyRecordBatch {
     batch: RecordBatch,
 }
@@ -46,7 +46,7 @@ impl From<RecordBatch> for PyRecordBatch {
     }
 }
 
-#[pyclass(name = "RecordBatchStream", module = "datafusion", subclass)]
+#[pyclass(name = "RecordBatchStream", module = "datafusion", subclass, frozen)]
 pub struct PyRecordBatchStream {
     stream: Arc<Mutex<SendableRecordBatchStream>>,
 }
@@ -61,12 +61,12 @@ impl PyRecordBatchStream {
 
 #[pymethods]
 impl PyRecordBatchStream {
-    fn next(&mut self, py: Python) -> PyResult<PyRecordBatch> {
+    fn next(&self, py: Python) -> PyResult<PyRecordBatch> {
         let stream = self.stream.clone();
         wait_for_future(py, next_stream(stream, true))?
     }
 
-    fn __next__(&mut self, py: Python) -> PyResult<PyRecordBatch> {
+    fn __next__(&self, py: Python) -> PyResult<PyRecordBatch> {
         self.next(py)
     }
 

--- a/src/sql/logical.rs
+++ b/src/sql/logical.rs
@@ -63,7 +63,7 @@ use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyBytes};
 
 use crate::expr::logical_node::LogicalNode;
 
-#[pyclass(name = "LogicalPlan", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "LogicalPlan", module = "datafusion", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyLogicalPlan {
     pub(crate) plan: Arc<LogicalPlan>,

--- a/src/store.rs
+++ b/src/store.rs
@@ -36,7 +36,12 @@ pub enum StorageContexts {
     HTTP(PyHttpContext),
 }
 
-#[pyclass(name = "LocalFileSystem", module = "datafusion.store", subclass)]
+#[pyclass(
+    frozen,
+    name = "LocalFileSystem",
+    module = "datafusion.store",
+    subclass
+)]
 #[derive(Debug, Clone)]
 pub struct PyLocalFileSystemContext {
     pub inner: Arc<LocalFileSystem>,
@@ -62,7 +67,7 @@ impl PyLocalFileSystemContext {
     }
 }
 
-#[pyclass(name = "MicrosoftAzure", module = "datafusion.store", subclass)]
+#[pyclass(frozen, name = "MicrosoftAzure", module = "datafusion.store", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyMicrosoftAzureContext {
     pub inner: Arc<MicrosoftAzure>,
@@ -134,7 +139,7 @@ impl PyMicrosoftAzureContext {
     }
 }
 
-#[pyclass(name = "GoogleCloud", module = "datafusion.store", subclass)]
+#[pyclass(frozen, name = "GoogleCloud", module = "datafusion.store", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyGoogleCloudContext {
     pub inner: Arc<GoogleCloudStorage>,
@@ -164,7 +169,7 @@ impl PyGoogleCloudContext {
     }
 }
 
-#[pyclass(name = "AmazonS3", module = "datafusion.store", subclass)]
+#[pyclass(frozen, name = "AmazonS3", module = "datafusion.store", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyAmazonS3Context {
     pub inner: Arc<AmazonS3>,
@@ -223,7 +228,7 @@ impl PyAmazonS3Context {
     }
 }
 
-#[pyclass(name = "Http", module = "datafusion.store", subclass)]
+#[pyclass(frozen, name = "Http", module = "datafusion.store", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyHttpContext {
     pub url: String,

--- a/src/substrait.rs
+++ b/src/substrait.rs
@@ -27,7 +27,7 @@ use datafusion_substrait::serializer;
 use datafusion_substrait::substrait::proto::Plan;
 use prost::Message;
 
-#[pyclass(name = "Plan", module = "datafusion.substrait", subclass)]
+#[pyclass(frozen, name = "Plan", module = "datafusion.substrait", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyPlan {
     pub plan: Plan,
@@ -59,7 +59,7 @@ impl From<Plan> for PyPlan {
 /// A PySubstraitSerializer is a representation of a Serializer that is capable of both serializing
 /// a `LogicalPlan` instance to Substrait Protobuf bytes and also deserialize Substrait Protobuf bytes
 /// to a valid `LogicalPlan` instance.
-#[pyclass(name = "Serde", module = "datafusion.substrait", subclass)]
+#[pyclass(frozen, name = "Serde", module = "datafusion.substrait", subclass)]
 #[derive(Debug, Clone)]
 pub struct PySubstraitSerializer;
 
@@ -112,7 +112,7 @@ impl PySubstraitSerializer {
     }
 }
 
-#[pyclass(name = "Producer", module = "datafusion.substrait", subclass)]
+#[pyclass(frozen, name = "Producer", module = "datafusion.substrait", subclass)]
 #[derive(Debug, Clone)]
 pub struct PySubstraitProducer;
 
@@ -129,7 +129,7 @@ impl PySubstraitProducer {
     }
 }
 
-#[pyclass(name = "Consumer", module = "datafusion.substrait", subclass)]
+#[pyclass(frozen, name = "Consumer", module = "datafusion.substrait", subclass)]
 #[derive(Debug, Clone)]
 pub struct PySubstraitConsumer;
 

--- a/src/udaf.rs
+++ b/src/udaf.rs
@@ -155,7 +155,7 @@ pub fn to_rust_accumulator(accum: PyObject) -> AccumulatorFactoryFunction {
 }
 
 /// Represents an AggregateUDF
-#[pyclass(name = "AggregateUDF", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "AggregateUDF", module = "datafusion", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyAggregateUDF {
     pub(crate) function: AggregateUDF,

--- a/src/udf.rs
+++ b/src/udf.rs
@@ -81,7 +81,7 @@ fn to_scalar_function_impl(func: PyObject) -> ScalarFunctionImplementation {
 }
 
 /// Represents a PyScalarUDF
-#[pyclass(name = "ScalarUDF", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "ScalarUDF", module = "datafusion", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyScalarUDF {
     pub(crate) function: ScalarUDF,

--- a/src/udtf.rs
+++ b/src/udtf.rs
@@ -31,7 +31,7 @@ use pyo3::exceptions::PyNotImplementedError;
 use pyo3::types::{PyCapsule, PyTuple};
 
 /// Represents a user defined table function
-#[pyclass(name = "TableFunction", module = "datafusion")]
+#[pyclass(frozen, name = "TableFunction", module = "datafusion")]
 #[derive(Debug, Clone)]
 pub struct PyTableFunction {
     pub(crate) name: String,

--- a/src/udwf.rs
+++ b/src/udwf.rs
@@ -210,7 +210,7 @@ pub fn to_rust_partition_evaluator(evaluator: PyObject) -> PartitionEvaluatorFac
 }
 
 /// Represents an WindowUDF
-#[pyclass(name = "WindowUDF", module = "datafusion", subclass)]
+#[pyclass(frozen, name = "WindowUDF", module = "datafusion", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyWindowUDF {
     pub(crate) function: WindowUDF,

--- a/src/unparser/dialect.rs
+++ b/src/unparser/dialect.rs
@@ -22,7 +22,7 @@ use datafusion::sql::unparser::dialect::{
 };
 use pyo3::prelude::*;
 
-#[pyclass(name = "Dialect", module = "datafusion.unparser", subclass)]
+#[pyclass(frozen, name = "Dialect", module = "datafusion.unparser", subclass)]
 #[derive(Clone)]
 pub struct PyDialect {
     pub dialect: Arc<dyn Dialect>,

--- a/src/unparser/mod.rs
+++ b/src/unparser/mod.rs
@@ -25,7 +25,7 @@ use pyo3::{exceptions::PyValueError, prelude::*};
 
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Unparser", module = "datafusion.unparser", subclass)]
+#[pyclass(frozen, name = "Unparser", module = "datafusion.unparser", subclass)]
 #[derive(Clone)]
 pub struct PyUnparser {
     dialect: Arc<dyn Dialect>,


### PR DESCRIPTION
# Which issue does this PR close?

* Closes #1250

---

# Rationale for this change

Several Python-facing PyO3 wrappers in this crate exposed APIs that required mutable borrows (e.g. `&mut self`) even though the underlying Rust objects are shared via `Arc` and intended for concurrent / re-entrant use from Python. When Python code holds onto those objects or uses them from multiple threads, PyO3 must hand out a `PyRefMut`, which triggers runtime "Already borrowed" panics when re-entrancy or cross-thread access occurs.

To make these thin wrappers behave like `SessionContext` (which is already `#[pyclass(frozen)]` and safe to share concurrently), this PR marks many `#[pyclass]` types as `frozen` and replaces exposed mutable borrows with methods that use interior mutability (`Arc<parking_lot::RwLock<_>>` / `Arc<parking_lot::Mutex<_>>`) for the small mutable state those types actually need.

This addresses the root cause of runtime borrow errors and allows Python code to keep references to wrappers and call methods concurrently across threads.

---

# What changes are included in this PR?

**High-level summary**

* Add `parking_lot` (lightweight locking primitives) to `Cargo.toml` and `Cargo.lock` and use `parking_lot::{RwLock, Mutex}` to implement interior mutability for Python-exposed wrappers.
* Most `#[pyclass(...)]` definitions are updated to `#[pyclass(..., frozen)]` so PyO3 will not require `PyRefMut` for access.
* Replace `&mut self` method signatures with `&self` where the method no longer needs exclusive borrow, and use internal locks to mutate internal state.
* Provide getters/setters for previously public `#[pyo3(get, set)]` fields that were replaced with interior-mutable fields (examples: `SqlSchema` now exposes getters/setters that lock and clone/replace contents).
* Rework the `CaseBuilder` wrapper to use `Arc<Mutex<Option<CaseBuilder>>>` and adopt a take/restore pattern so multiple calls (including calls that return errors) preserve the builder's internal state while making the wrapper safe for concurrent use.
* Change `PyConfig` to hold `Arc<RwLock<ConfigOptions>>` and modify `get`, `set`, `get_all`, and `__repr__` to use read/write locks appropriately.
* Change `PyDataFrame` caching to use `Arc<Mutex<Option<(Vec<RecordBatch>, bool)>>>` and update repr/html methods to use interior locks. Methods that produced `&mut self` are now `&self`.
* Make `PyRecordBatchStream::next` / `__next__` take `&self` instead of `&mut self`.
* Adjust a large number of thin wrappers and enums to be `frozen` to ensure the wrappers can be shared safely from Python.

**Notable changed files (non-exhaustive)**

* `Cargo.toml`, `Cargo.lock` — add `parking_lot = "0.12"`.
* `python/tests/test_concurrency.py` — new concurrency tests exercising `SqlSchema`, `Config`, and `DataFrame` from multiple threads.
* `python/tests/test_expr.py` — updates and additions to test `CaseBuilder` behavior and avoid boolean literal linter issue.
* `src/common/schema.rs` — `SqlSchema` now uses `Arc<RwLock<...>>` for `name`, `tables`, `views`, and `functions` and provides getters/setters.
* `src/config.rs` — `PyConfig` holds `Arc<RwLock<ConfigOptions>>`, methods updated.
* `src/dataframe.rs` — internal caching refactored to `Arc<Mutex<...>>`, repr methods made `&self`.
* `src/expr/conditional_expr.rs` — `PyCaseBuilder` changed to `Arc<Mutex<Option<CaseBuilder>>>` and methods adapted to take/store the builder safely; `case`/`when` constructors updated.
* `src/functions.rs` — `case` and `when` functions return the new `PyCaseBuilder` wrapper via `into()`.
* Many other `src/*.rs` files — `#[pyclass(..., frozen)]` added to many thin wrappers and enums so they no longer require `&mut self` usage in Python.

**Behavioral notes**

* `CaseBuilder` API: `when`, `otherwise`, and `end` now return `PyDataFusionResult` and preserve the builder state on both success and failure (the builder is stored back into the wrapper after an attempted operation). This preserves the semantics that Python code can reuse the builder and that errors don't irreversibly consume the builder.

---

# Are these changes tested?

* Yes: a new Python test (`python/tests/test_concurrency.py`) exercises several wrappers concurrently across threads to reproduce the race/borrow conditions and assert expected behavior. Additional tests for case builder correctness and state preservation were added/updated in `python/tests/test_expr.py`.

* Please run the full test suite (Rust + Python tests) in CI. I recommend running `maturin`/`pytest` for the python bindings and `cargo test` for Rust tests locally or in CI.

---

# Are there any user-facing changes?

* **API surface:** The public Python API remains compatible at the call-site level for typical consumers — method names and signatures are preserved for end users. Some methods that previously required a mutable borrow at the PyO3 layer now accept `&self` from Python code; this is a transparent improvement for callers.

* **Potential incompatibilities:** Marking classes `#[pyclass(frozen)]` changes how PyO3 exposes attribute mutation at the Python attribute level. Any user code that relied on obtaining a mutable reference (`PyRefMut`) and mutating the wrapper directly (rather than using the provided setters/methods) may no longer work. The intended mutation points are now exposed via explicit setters/methods (for example `SqlSchema.set_name`, `SqlSchema.set_tables`, etc.). Please review the PR for any specific wrappers your code depends on and adjust to call the explicit setters or APIs provided.

---

# Risk & compatibility

* The changes are focused and low-level: they replace external mutation with interior mutability and mark wrappers as `frozen`.
* Risk areas that need careful review:

  * Ensure no long-lived locks are held across Python callbacks to avoid deadlocks or blocking Python threads.
  * Ensure getters return clones (not references) to avoid holding locks while Python code touches returned objects.
  * Confirm error semantics for `CaseBuilder` remain intuitive; errors should not permanently consume builder state.
  * Ensure no accidental lifetime/ownership regressions introduced by switching to `Arc<...>` wrappers.

---

# Notes for reviewers

* Focus review on the concurrent patterns (places that lock RwLock/Mutex) and ensure we don't hold locks while calling back into Python or performing expensive operations.
* Verify `CaseBuilder` take/restore logic correctly preserves state on both success and failure paths.
* Verify every `#[pyclass(frozen)]` change does not break a previously intended API (particularly for types previously annotated with `#[pyo3(get, set)]`). If a previously writable attribute was necessary, confirm the PR provides an explicit setter or alternate API.
* Check that `get`/`get_all`/`set` on `PyConfig` behave as before and that conversion to/from Python objects remains correct.
* The PR uses `parking_lot` (no poisoning semantics, faster locking). Confirm this dependency is acceptable for the project and CI builds. For context, Datafusion already uses `parking_lot`.
* The PR intentionally keeps public Python APIs stable while preventing PyO3 borrow errors. If maintainers prefer a different interior-mutation primitive (e.g., `std::sync::{Arc, Mutex}`) we can adjust, but `parking_lot` offers simpler ergonomics and avoids poisoning semantics.
