### PR TITLE
feat: expose DataFrame.write_table

### DIFF
--- a/python/datafusion/__init__.py
+++ b/python/datafusion/__init__.py
@@ -45,7 +45,13 @@ from .context import (
     SessionContext,
     SQLOptions,
 )
-from .dataframe import DataFrame, ParquetColumnOptions, ParquetWriterOptions
+from .dataframe import (
+    DataFrame,
+    DataFrameWriteOptions,
+    InsertOp,
+    ParquetColumnOptions,
+    ParquetWriterOptions,
+)
 from .dataframe_formatter import configure_formatter
 from .expr import (
     Expr,
@@ -75,9 +81,11 @@ __all__ = [
     "Config",
     "DFSchema",
     "DataFrame",
+    "DataFrameWriteOptions",
     "Database",
     "ExecutionPlan",
     "Expr",
+    "InsertOp",
     "LogicalPlan",
     "ParquetColumnOptions",
     "ParquetWriterOptions",

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -941,7 +941,7 @@ class DataFrame:
             with_header: If true, output the CSV header row.
             write_options: Options that impact how the DataFrame is written.
         """
-        self.df.write_csv(str(path), with_header, write_options=write_options)
+        self.df.write_csv(str(path), with_header, write_options._raw_write_options)
 
     @overload
     def write_parquet(
@@ -1014,7 +1014,10 @@ class DataFrame:
             compression_level = compression.get_default_level()
 
         self.df.write_parquet(
-            str(path), compression.value, compression_level, write_options
+            str(path),
+            compression.value,
+            compression_level,
+            write_options._raw_write_options,
         )
 
     def write_parquet_with_options(
@@ -1071,7 +1074,7 @@ class DataFrame:
             str(path),
             options_internal,
             column_specific_options_internal,
-            write_options,
+            write_options._raw_write_options,
         )
 
     def write_json(
@@ -1085,7 +1088,7 @@ class DataFrame:
             path: Path of the JSON file to write.
             write_options: Options that impact how the DataFrame is written.
         """
-        self.df.write_json(str(path), write_options=write_options)
+        self.df.write_json(str(path), write_options=write_options._raw_write_options)
 
     def write_table(
         self, table_name: str, write_options: DataFrameWriteOptions | None = None
@@ -1096,7 +1099,7 @@ class DataFrame:
         Not all table providers support writing operations. See the individual
         implementations for details.
         """
-        self.df.write_table(table_name, write_options)
+        self.df.write_table(table_name, write_options._raw_write_options)
 
     def to_arrow_table(self) -> pa.Table:
         """Execute the :py:class:`DataFrame` and convert it into an Arrow Table.
@@ -1275,11 +1278,11 @@ class DataFrameWriteOptions:
         """Instantiate writer options for DataFrame."""
         write_options = DataFrameWriteOptionsInternal()
         if insert_operation is not None:
-            write_options = write_options.with_insert_operation(insert_operation)
+            write_options = write_options.with_insert_operation(insert_operation.value)
         write_options = write_options.with_single_file_output(single_file_output)
         if partition_by is not None:
             if isinstance(partition_by, str):
-                partition_by = [single_file_output]
+                partition_by = [partition_by]
             write_options = write_options.with_partition_by(partition_by)
 
         sort_by_raw = sort_list_to_raw_sort_list(sort_by)

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -1257,8 +1257,16 @@ class InsertOp(Enum):
     """
 
     APPEND = InsertOpInternal.APPEND
+    """Appends new rows to the existing table without modifying any existing rows."""
+
     REPLACE = InsertOpInternal.REPLACE
+    """Replace existing rows that collide with the inserted rows.
+
+    Replacement is typically based on a unique key or primary key.
+    """
+
     OVERWRITE = InsertOpInternal.OVERWRITE
+    """Overwrites all existing rows in the table with the new rows."""
 
 
 class DataFrameWriteOptions:

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -928,14 +928,20 @@ class DataFrame:
         """
         return DataFrame(self.df.except_all(other.df))
 
-    def write_csv(self, path: str | pathlib.Path, with_header: bool = False) -> None:
+    def write_csv(
+        self,
+        path: str | pathlib.Path,
+        with_header: bool = False,
+        write_options: DataFrameWriteOptions | None = None,
+    ) -> None:
         """Execute the :py:class:`DataFrame`  and write the results to a CSV file.
 
         Args:
             path: Path of the CSV file to write.
             with_header: If true, output the CSV header row.
+            write_options: Options that impact how the DataFrame is written.
         """
-        self.df.write_csv(str(path), with_header)
+        self.df.write_csv(str(path), with_header, write_options=write_options)
 
     @overload
     def write_parquet(
@@ -943,6 +949,7 @@ class DataFrame:
         path: str | pathlib.Path,
         compression: str,
         compression_level: int | None = None,
+        write_options: DataFrameWriteOptions | None = None,
     ) -> None: ...
 
     @overload
@@ -951,6 +958,7 @@ class DataFrame:
         path: str | pathlib.Path,
         compression: Compression = Compression.ZSTD,
         compression_level: int | None = None,
+        write_options: DataFrameWriteOptions | None = None,
     ) -> None: ...
 
     @overload
@@ -959,6 +967,7 @@ class DataFrame:
         path: str | pathlib.Path,
         compression: ParquetWriterOptions,
         compression_level: None = None,
+        write_options: DataFrameWriteOptions | None = None,
     ) -> None: ...
 
     def write_parquet(
@@ -966,8 +975,11 @@ class DataFrame:
         path: str | pathlib.Path,
         compression: Union[str, Compression, ParquetWriterOptions] = Compression.ZSTD,
         compression_level: int | None = None,
+        write_options: DataFrameWriteOptions | None = None,
     ) -> None:
         """Execute the :py:class:`DataFrame` and write the results to a Parquet file.
+
+        LZO compression is not yet implemented in arrow-rs and is therefore excluded.
 
         Args:
             path: Path of the Parquet file to write.
@@ -980,10 +992,10 @@ class DataFrame:
                 - "lz4": LZ4 compression.
                 - "lz4_raw": LZ4_RAW compression.
                 - "zstd": Zstandard compression.
-            Note: LZO is not yet implemented in arrow-rs and is therefore excluded.
             compression_level: Compression level to use. For ZSTD, the
                 recommended range is 1 to 22, with the default being 4. Higher levels
                 provide better compression but slower speed.
+            write_options: Options that impact how the DataFrame is written.
         """
         if isinstance(compression, ParquetWriterOptions):
             if compression_level is not None:
@@ -1001,10 +1013,15 @@ class DataFrame:
         ):
             compression_level = compression.get_default_level()
 
-        self.df.write_parquet(str(path), compression.value, compression_level)
+        self.df.write_parquet(
+            str(path), compression.value, compression_level, write_options
+        )
 
     def write_parquet_with_options(
-        self, path: str | pathlib.Path, options: ParquetWriterOptions
+        self,
+        path: str | pathlib.Path,
+        options: ParquetWriterOptions,
+        write_options: DataFrameWriteOptions | None = None,
     ) -> None:
         """Execute the :py:class:`DataFrame` and write the results to a Parquet file.
 
@@ -1013,6 +1030,7 @@ class DataFrame:
         Args:
             path: Path of the Parquet file to write.
             options: Sets the writer parquet options (see `ParquetWriterOptions`).
+            write_options: Options that impact how the DataFrame is written.
         """
         options_internal = ParquetWriterOptionsInternal(
             options.data_pagesize_limit,
@@ -1053,15 +1071,21 @@ class DataFrame:
             str(path),
             options_internal,
             column_specific_options_internal,
+            write_options,
         )
 
-    def write_json(self, path: str | pathlib.Path) -> None:
+    def write_json(
+        self,
+        path: str | pathlib.Path,
+        write_options: DataFrameWriteOptions | None = None,
+    ) -> None:
         """Execute the :py:class:`DataFrame` and write the results to a JSON file.
 
         Args:
             path: Path of the JSON file to write.
+            write_options: Options that impact how the DataFrame is written.
         """
-        self.df.write_json(str(path))
+        self.df.write_json(str(path), write_options=write_options)
 
     def write_table(
         self, table_name: str, write_options: DataFrameWriteOptions | None = None

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -2322,6 +2322,25 @@ def test_write_parquet_options_error(df, tmp_path):
         df.write_parquet(str(tmp_path), options, compression_level=1)
 
 
+def test_write_table(ctx, df):
+    batch = pa.RecordBatch.from_arrays(
+        [pa.array([1, 2, 3])],
+        names=["a"],
+    )
+
+    ctx.register_record_batches("t", [[batch]])
+
+    df = ctx.table("t").with_column("a", column("a") * literal(-1))
+
+    ctx.table("t").show()
+
+    df.write_table("t")
+    result = ctx.table("t").sort(column("a")).collect()[0][0].to_pylist()
+    expected = [-3, -2, -1, 1, 2, 3]
+
+    assert result == expected
+
+
 def test_dataframe_export(df) -> None:
     # Guarantees that we have the canonical implementation
     # reading our dataframe export

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -1078,43 +1078,24 @@ impl From<PyDataFrameWriteOptions> for DataFrameWriteOptions {
 #[pymethods]
 impl PyDataFrameWriteOptions {
     #[new]
-    fn new() -> Self {
+    fn new(
+        insert_operation: Option<PyInsertOp>,
+        single_file_output: bool,
+        partition_by: Option<Vec<String>>,
+        sort_by: Option<Vec<PySortExpr>>,
+    ) -> Self {
+        let insert_operation = insert_operation.map(Into::into).unwrap_or(InsertOp::Append);
+        let sort_by = sort_by
+            .unwrap_or_default()
+            .into_iter()
+            .map(Into::into)
+            .collect();
         Self {
-            insert_operation: InsertOp::Append,
-            single_file_output: false,
-            partition_by: vec![],
-            sort_by: vec![],
+            insert_operation,
+            single_file_output,
+            partition_by: partition_by.unwrap_or_default(),
+            sort_by,
         }
-    }
-
-    pub fn with_insert_operation(&self, insert_operation: PyInsertOp) -> Self {
-        let mut result = self.clone();
-
-        result.insert_operation = insert_operation.into();
-        result
-    }
-
-    pub fn with_single_file_output(&self, single_file_output: bool) -> Self {
-        let mut result = self.clone();
-
-        result.single_file_output = single_file_output;
-        result
-    }
-
-    /// Sets the partition_by columns for output partitioning
-    pub fn with_partition_by(&self, partition_by: Vec<String>) -> Self {
-        let mut result = self.clone();
-
-        result.partition_by = partition_by;
-        result
-    }
-
-    /// Sets the sort_by columns for output sorting
-    pub fn with_sort_by(&self, sort_by: Vec<PySortExpr>) -> Self {
-        let mut result = self.clone();
-
-        result.sort_by = sort_by.into_iter().map(Into::into).collect();
-        result
     }
 }
 

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -746,10 +746,10 @@ impl PyDataFrame {
     /// Write a `DataFrame` to a CSV file.
     fn write_csv(
         &self,
+        py: Python,
         path: &str,
         with_header: bool,
         write_options: Option<PyDataFrameWriteOptions>,
-        py: Python,
     ) -> PyDataFusionResult<()> {
         let csv_options = CsvOptions {
             has_header: Some(with_header),
@@ -1078,13 +1078,20 @@ impl From<PyDataFrameWriteOptions> for DataFrameWriteOptions {
 #[pymethods]
 impl PyDataFrameWriteOptions {
     #[new]
-    fn new(insert_operation: PyInsertOp) -> Self {
+    fn new() -> Self {
         Self {
-            insert_operation: insert_operation.into(),
+            insert_operation: InsertOp::Append,
             single_file_output: false,
             partition_by: vec![],
             sort_by: vec![],
         }
+    }
+
+    pub fn with_insert_operation(&self, insert_operation: PyInsertOp) -> Self {
+        let mut result = self.clone();
+
+        result.insert_operation = insert_operation.into();
+        result
     }
 
     pub fn with_single_file_output(&self, single_file_output: bool) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,8 @@ fn _internal(py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<context::PySessionContext>()?;
     m.add_class::<context::PySQLOptions>()?;
     m.add_class::<dataframe::PyDataFrame>()?;
+    m.add_class::<dataframe::PyInsertOp>()?;
+    m.add_class::<dataframe::PyDataFrameWriteOptions>()?;
     m.add_class::<dataframe::PyParquetColumnOptions>()?;
     m.add_class::<dataframe::PyParquetWriterOptions>()?;
     m.add_class::<udf::PyScalarUDF>()?;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1005

 # Rationale for this change

In addition to closing #1005 this exposes an important function in DataFrame operations, writing to tables. This functionality exists in the upstream DataFusion project but it has not previously been exposed to python. Now that we have external table support and external catalogs, we should make this function accessible to users.

# What changes are included in this PR?

- Adds dataframe writer Python wrapper.
- Adds insert operation enum Python wrapper.
- Exposes `DataFrame.write_table`
- Adds unit test coverage
- Adds dataframe writer options to `write_csv`, `write_json`, and `write_parquet`

# Are there any user-facing changes?

There are no breaking changes. The existing methods have a new optional parameter. If it is not provided then the operations are unchanged.