### PR TITLE
fix: remove todo from indexed field key

### DIFF
--- a/crates/core/src/expr/indexed_field.rs
+++ b/crates/core/src/expr/indexed_field.rs
@@ -21,6 +21,7 @@ use datafusion::logical_expr::expr::{GetFieldAccess, GetIndexedField};
 use pyo3::prelude::*;
 
 use super::literal::PyLiteral;
+use crate::errors::py_unsupported_variant_err;
 use crate::expr::PyExpr;
 
 #[pyclass(
@@ -68,7 +69,9 @@ impl PyGetIndexedField {
     fn key(&self) -> PyResult<PyLiteral> {
         match &self.indexed_field.field {
             GetFieldAccess::NamedStructField { name, .. } => Ok(name.clone().into()),
-            _ => todo!(),
+            GetFieldAccess::ListIndex { .. } | GetFieldAccess::ListRange { .. } => Err(
+                py_unsupported_variant_err("GetIndexedField.key is only supported for struct fields"),
+            ),
         }
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #552.

# Rationale for this change

Issue #552 tracks replacing remaining `todo!()` calls with explicit errors. The only remaining `todo!()` was in `PyGetIndexedField::key`, where unsupported list-index and list-range field access could panic instead of returning a Python error.

# What changes are included in this PR?

This updates `PyGetIndexedField::key` to keep returning the struct field key for `NamedStructField`, and to return the existing unsupported-variant error for list index and list range access.

# Are there any user-facing changes?

No API change is intended. This only replaces an internal panic path with an explicit Python error for unsupported field access forms.

# Testing

- `cargo fmt --check`
- `wsl bash -lc "cd /mnt/c/Users/bhara/OneDrive/Desktop/Python/datafusion-python && cargo check -p datafusion-python"`
- `rg -n "todo!\\(" crates/core/src -g "*.rs"` returned no matches
