### PR TITLE
Add typed Protocols for FFI capsule exports (part of #1577)

### DIFF
--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -145,6 +145,29 @@ class PhysicalOptimizerRuleExportable(Protocol):
     def __datafusion_physical_optimizer_rule__(self) -> object: ...  # noqa: D105
 
 
+class ExtensionOptionsExportable(Protocol):
+    """Type hint for object that has __datafusion_extension_options__ PyCapsule.
+
+    The method returns a PyCapsule wrapping an ``FFI_ExtensionOptions``,
+    typically produced by a separate compiled extension and consumed by
+    :py:meth:`SessionConfig.with_extension`.
+    """
+
+    def __datafusion_extension_options__(self) -> object: ...  # noqa: D105
+
+
+class TaskContextProviderExportable(Protocol):
+    """Type hint for object that has __datafusion_task_context_provider__ PyCapsule.
+
+    The method returns a PyCapsule wrapping an ``FFI_TaskContextProvider``.
+    :py:class:`SessionContext` exposes one for its own task context; a
+    separate compiled extension can decode it (or one of its own) using
+    the matching Rust-side ``from_pycapsule`` helper.
+    """
+
+    def __datafusion_task_context_provider__(self) -> object: ...  # noqa: D105
+
+
 class SessionConfig:
     """Session configuration options."""
 
@@ -337,12 +360,14 @@ class SessionConfig:
         self.config_internal = self.config_internal.set(key, value)
         return self
 
-    def with_extension(self, extension: Any) -> SessionConfig:
+    def with_extension(self, extension: ExtensionOptionsExportable) -> SessionConfig:
         """Create a new configuration using an extension.
 
         Args:
             extension: A custom configuration extension object. These are
-            shared from another DataFusion extension library.
+            shared from another DataFusion extension library. It must expose
+            an ``__datafusion_extension_options__`` PyCapsule, see
+            :py:class:`ExtensionOptionsExportable`.
 
         Returns:
             A new :py:class:`SessionConfig` object with the updated setting.

--- a/python/datafusion/user_defined.py
+++ b/python/datafusion/user_defined.py
@@ -1121,6 +1121,15 @@ def _wrap_session_kwarg_for_udtf(func: Callable[..., Any]) -> Callable[..., Any]
     return adapter
 
 
+class TableFunctionExportable(Protocol):
+    """Type hint for object that has __datafusion_table_function__ PyCapsule.
+
+    https://datafusion.apache.org/python/user-guide/io/table_provider.html
+    """
+
+    def __datafusion_table_function__(self, session: Any) -> object: ...  # noqa: D105
+
+
 class TableFunction:
     """Class for performing user-defined table functions (UDTF).
 
@@ -1131,7 +1140,7 @@ class TableFunction:
     def __init__(
         self,
         name: str,
-        func: Callable[..., Any],
+        func: Callable[..., Any] | TableFunctionExportable,
         ctx: SessionContext | None = None,
         *,
         with_session: bool = False,
@@ -1189,6 +1198,10 @@ class TableFunction:
         *,
         with_session: bool = False,
     ) -> TableFunction: ...
+
+    @overload
+    @staticmethod
+    def udtf(func: TableFunctionExportable, name: str) -> TableFunction: ...
 
     @staticmethod
     def udtf(*args: Any, with_session: bool = False, **kwargs: Any):


### PR DESCRIPTION
# Which issue does this PR close?

Part of #1577. This PR covers 3 of the 6 items in that umbrella issue (see "Not included" below for why the rest are left out).

# Rationale for this change

The FFI-pipeline typing audit referenced in #1577 found several places where DataFusion's FFI types are already imported on the Rust side, but the Python surface has no typed `Protocol` describing the expected PyCapsule dunder method. Callers are left to read the Rust source or guess the signature.

# What changes are included in this PR?

Adds three `Protocol` classes, following the existing `TableProviderExportable` / `PhysicalOptimizerRuleExportable` pattern (name, docstring, and single dunder method), and points the corresponding parameter/return type hints at them:

- `datafusion.user_defined.TableFunctionExportable`: describes the `__datafusion_table_function__(self, session)` PyCapsule method already duck-typed via `hasattr` in `TableFunction.__init__` / `TableFunction.udtf` (those `hasattr` checks are the actual runtime dispatch and are left untouched). The `func` parameter on `TableFunction.__init__` is now typed as `Callable[..., Any] | TableFunctionExportable`, and a new `udtf` overload documents the FFI-capsule call shape.
- `datafusion.context.ExtensionOptionsExportable`: describes `__datafusion_extension_options__(self)`, required by `SessionConfig.with_extension` (see `crates/core/src/context.rs`, `SessionConfig::with_extension`). `with_extension`'s `extension` parameter is now typed against it.
- `datafusion.context.TaskContextProviderExportable`: describes `__datafusion_task_context_provider__(self)`. `SessionContext` already exposes one of these in `context.py`, and this protocol documents the shape for other extensions that want to decode or produce one, matching the `task_context_from_pycapsule` helper already in `crates/util/src/lib.rs`.

# Not included from #1577's item list

The remaining 3 items are execution-engine-level questions rather than typing changes, so I split each into its own issue for design discussion:

- **`FFI_TableProvider`, `TableProvider(ABC)` (item 2):** wiring a plain-Python subclass through to the Rust `TableProvider` trait needs a new `RustWrappedPyTableProvider`. Design discussion: #1668
- **`FFI_TableProviderFactory`, `from_pycapsule` helper (item 5):** the call site this item points at passes an argument to the dunder method, which the existing `from_pycapsule!` / `try_from_pycapsule!` macros don't support (`call0()` only). Discussion: #1669
- **`WindowUDF`, `ABC` equivalent to `Accumulator` (item 6):** `WindowEvaluator` already provides this capability; it's just not `ABCMeta`-shaped because the required `evaluate*` method depends on a flag matrix. Confirming whether the literal ABC form is still wanted: #1670

# Are there any user-facing changes?

No runtime behavior changes. This only adds type hints (new `Protocol` classes) and updates existing parameter/return annotations to reference them.

Validation run locally:

- `uvx ruff@0.15.1 check python/datafusion/user_defined.py python/datafusion/context.py` - passed
- `uvx ruff@0.15.1 format --check python/datafusion/user_defined.py python/datafusion/context.py` - passed
- `git diff --check` - passed
- `python -m py_compile` on both files - passed
