### PR TITLE
docs: document regular expression function arguments

### DIFF
--- a/python/datafusion/functions/__init__.py
+++ b/python/datafusion/functions/__init__.py
@@ -1761,6 +1761,11 @@ def regexp_like(
     Tests a string using a regular expression returning true if at least one match,
     false otherwise.
 
+    Args:
+        string: Data to test against the regular expression.
+        regex: Regular expression to search for.
+        flags: Optional regular expression flags to control regex behavior.
+
     Examples:
         >>> ctx = dfn.SessionContext()
         >>> df = ctx.from_pydict({"a": ["hello123"]})
@@ -1796,6 +1801,11 @@ def regexp_match(
 
     Returns an array with each element containing the leftmost-first match of the
     corresponding index in ``regex`` to string in ``string``.
+
+    Args:
+        string: Data to match against the regular expression.
+        regex: Regular expression to search for.
+        flags: Optional regular expression flags to control regex behavior.
 
     Examples:
         >>> ctx = dfn.SessionContext()
@@ -1838,6 +1848,13 @@ def regexp_replace(
 
     Supported flags with the addition of 'g' can be found at
     <https://docs.rs/regex/latest/regex/#grouping-and-flags>
+
+    Args:
+        string: Data to search for the regular expression match.
+        pattern: Regular expression to search for.
+        replacement: Text substituted for each match.
+        flags: Optional regular expression flags to control regex behavior. Add
+            ``g`` to replace every match rather than only the first.
 
     Examples:
         >>> ctx = dfn.SessionContext()
@@ -1884,6 +1901,12 @@ def regexp_count(
 
     Optional start position (the first position is 1) to search for the regular
     expression.
+
+    Args:
+        string: Data to search for the regular expression match.
+        pattern: Regular expression to search for.
+        start: Optional position to start the search (the first position is 1).
+        flags: Optional regular expression flags to control regex behavior.
 
     Examples:
         >>> ctx = dfn.SessionContext()

--- a/python/datafusion/functions/__init__.py
+++ b/python/datafusion/functions/__init__.py
@@ -1764,7 +1764,7 @@ def regexp_like(
     Args:
         string: Data to test against the regular expression.
         regex: Regular expression to search for.
-        flags: Optional regular expression flags to control regex behavior.
+        flags: Flags to control regex behavior.
 
     Examples:
         >>> ctx = dfn.SessionContext()
@@ -1805,7 +1805,7 @@ def regexp_match(
     Args:
         string: Data to match against the regular expression.
         regex: Regular expression to search for.
-        flags: Optional regular expression flags to control regex behavior.
+        flags: Flags to control regex behavior.
 
     Examples:
         >>> ctx = dfn.SessionContext()
@@ -1853,8 +1853,8 @@ def regexp_replace(
         string: Data to search for the regular expression match.
         pattern: Regular expression to search for.
         replacement: Text substituted for each match.
-        flags: Optional regular expression flags to control regex behavior. Add
-            ``g`` to replace every match rather than only the first.
+        flags: Flags to control regex behavior. Add ``g`` to replace every
+            match rather than only the first.
 
     Examples:
         >>> ctx = dfn.SessionContext()
@@ -1905,8 +1905,8 @@ def regexp_count(
     Args:
         string: Data to search for the regular expression match.
         pattern: Regular expression to search for.
-        start: Optional position to start the search (the first position is 1).
-        flags: Optional regular expression flags to control regex behavior.
+        start: Position to start the search (the first position is 1).
+        flags: Flags to control regex behavior.
 
     Examples:
         >>> ctx = dfn.SessionContext()


### PR DESCRIPTION
# Which issue does this PR close?

Related to #1463.

# Rationale for this change

`regexp_instr` documents every parameter it takes in an `Args:` section. The four
other `regexp_*` functions document none. Someone reading the generated API docs to
find out what `flags` accepts, or where `start` counts from, gets an answer for one
function in the family and nothing for the rest.

This is the same kind of small focused pass as #1527, applied to the regular
expression family.

# What changes are included in this PR?

Adds an `Args:` section to four functions in `python/datafusion/functions/__init__.py`:

- `regexp_like`
- `regexp_match`
- `regexp_replace`
- `regexp_count`

Where a parameter also exists on `regexp_instr` (`regex`, `start`, `flags`), the
wording follows what `regexp_instr` already says, so the family reads consistently.
The `flags` entry on `regexp_replace` also records the `g` behavior that the prose
above it and its own example already show.

Nothing else in the file changes. Signatures, type hints, runtime code, and existing
examples are untouched.

# Are there any user-facing changes?

Yes, documentation only. The generated API docs now list argument descriptions for
these four functions. Runtime behavior is unchanged.

# Validation

Pre-commit, scoped to the changed file:

```console
$ pre-commit run --files python/datafusion/functions/__init__.py
Lint GitHub Actions workflow files...................(no files to check)Skipped
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Rust fmt.............................................(no files to check)Skipped
Rust clippy..........................................(no files to check)Skipped
codespell................................................................Passed
uv-lock..............................................(no files to check)Skipped
```

Ruff on its own, pinned to the version in `.pre-commit-config.yaml`:

```console
$ ruff@0.15.1 check --config pyproject.toml python/datafusion/functions/__init__.py
All checks passed!
$ ruff@0.15.1 format --check --config pyproject.toml python/datafusion/functions/__init__.py
1 file already formatted
```

The repository enables `--doctest-modules` over `python/datafusion`, so the examples
in these docstrings run as tests. Against a locally built extension:

```console
$ pytest python/datafusion/functions/__init__.py -q -k regexp
5 passed, 231 deselected, 2 warnings in 2.39s

$ pytest python/datafusion/functions/__init__.py -q
236 passed, 2 warnings in 2.06s
```

Whitespace:

```console
$ git diff --check
```

# LLM-generated code disclosure

These docstring additions were prepared with the assistance of Claude and reviewed
against each function signature before submission.
