### PR TITLE
chore: update datafusion dependency to 55.0.0rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b952ca5a8046ad741b60f142d6eca4aeebcad615694202bc64c5341f23e32c5b"
+checksum = "61d285d16bce7d0be61912f7928342b673067b6b7d7ef6cc179258ba7de1fecf"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a13b8d3008c4e9063c597a08f46446fe3fd5789277127672d6c0bdbb43b1ff"
+checksum = "757ef1836251e88222542a7da2623bc1c9cb9e20afefa6db2c41e79991cd91d4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9486151b2f0785bafc6fa04fc5c99fcb4495455662e58787ea32eaaed33c4192"
+checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -147,6 +147,7 @@ dependencies = [
  "chrono-tz",
  "half",
  "hashbrown 0.17.1",
+ "libc",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -154,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-avro"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4f9b23a0d7b613acb59fa20bdbe0f80ffdae6411498378340b3915e45f5b84"
+checksum = "9fb45cd6bd2b25c0965793b83200eaca82214273a8030fbbc2d783e4c7c65a61"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -178,21 +179,21 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4776577a87794bfdf0b4e90e2ea12454fa7738ea2823c4be5b9d1851da7b434"
+checksum = "c12b576ef18c1deb80925a248b25ad84f419198d791b8e293fc6aaa60441fe90"
 dependencies = [
  "bytes",
  "half",
- "num-bigint",
+ "num-bigint 0.5.1",
  "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ad451ce4f98710828a455b96991b8f031deb2e67f5fcad6773f017e4a69c3a"
+checksum = "68338a9096a5dc9bc11927c58c43a8526d96bf6abd2012ef6c0c9f505991cc79"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -201,7 +202,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "comfy-table",
  "half",
@@ -212,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa7bf96d6141a7bcca2eed57c7c9767d2a2175281857b8a7b68308992864784"
+checksum = "25011b52b346407d497ef0030e12b45e4f2d0cc279efc09c4f3d09106db30e36"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -227,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38fe43e2e8704360f1464e6e8cc4fc381ef02cc4fb0192afa8df1aaa0115c66"
+checksum = "723fe4aeed7604e00b9883a465af4ff0a0e6c44c03e41a68c3d1cbc403e0e44d"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -240,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29dac499fcbc6ba74ee0324057821d381929a48526a3966bd9dffb44aa06d98c"
+checksum = "149437b14371f5b9ec60f5ddc751483ae99d7a7072653c0075e5e469156eea7b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -256,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe05e916ddc50f4c7a363cd69c0ef5894fcee063517e9a0b8582f0c56746af6"
+checksum = "f18b9123ccfec418a663f821c9a034af339711678c11ffe00d3ec07da5ff9f7e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -281,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e13dbdc2a9c053c10c7baa6e30faee04a180aa7ce88e471835850ce37abd20b"
+checksum = "e6c08dff0686cf23ca4f562803f191ccbeb726dbae6309cd4b4aaf65e0f2c979"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -294,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-pyarrow"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8d967bdece4fa5a0199706730175b3df3448b87e350250a86eb6c22639e445"
+checksum = "c196ecc25b3a8dcbc1d842f2619cee653dcfa2fb8b56a291bc0481c3cf5c3821"
 dependencies = [
  "arrow-array",
  "arrow-data",
@@ -306,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5a1f8c733d15260b305683472ee8ad89c62cbd706703ca873b90d051b41592"
+checksum = "bbec439386df71ad570e6758a946111322b9e9dc8db83b5527321f0b4c9119c2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -319,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e4969dc350d571766247143ab36a5187d095d3d3690970408bc630d47c69e5"
+checksum = "e6fed2ca0d1eade57e811cbe73b98ad50cc08a1183e13b2d2aa43a7df593f40e"
 dependencies = [
  "bitflags",
  "serde_core",
@@ -330,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402770dba90865359d98d1ef92ef16e23d75c0cca9c2c880c8a05468b7743bf9"
+checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -344,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b0afbb8b9016700938291123df30838b89decc3213dba00852021988b170d3"
+checksum = "c838a25bb3691e919e0f617616ac51a4ff8517a952e29ca133cf0c22b2ce65b1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -428,9 +429,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bigdecimal"
@@ -440,7 +441,7 @@ checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
 dependencies = [
  "autocfg",
  "libm",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -790,8 +791,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -843,8 +844,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -867,8 +868,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -890,8 +891,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -916,8 +917,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "futures",
  "log",
@@ -926,8 +927,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "async-compression",
@@ -962,8 +963,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -976,6 +977,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
+ "datafusion-proto-models",
  "datafusion-session",
  "futures",
  "itertools 0.15.0",
@@ -985,8 +987,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-avro"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "arrow-avro",
@@ -1003,8 +1005,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1016,6 +1018,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
+ "datafusion-proto-models",
  "datafusion-session",
  "futures",
  "object_store",
@@ -1025,8 +1028,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1038,6 +1041,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
+ "datafusion-proto-models",
  "datafusion-session",
  "futures",
  "object_store",
@@ -1047,8 +1051,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1065,6 +1069,7 @@ dependencies = [
  "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
+ "datafusion-proto-models",
  "datafusion-pruning",
  "datafusion-session",
  "futures",
@@ -1078,13 +1083,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 
 [[package]]
 name = "datafusion-execution"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1108,8 +1113,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1121,6 +1126,8 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
+ "datafusion-proto-common",
+ "datafusion-proto-models",
  "indexmap",
  "itertools 0.15.0",
  "recursive",
@@ -1130,8 +1137,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1141,8 +1148,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ffi"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1195,12 +1202,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "arrow-buffer",
- "base64 0.23.0",
+ "base64 0.23.1",
  "blake2",
  "blake3",
  "chrono",
@@ -1226,8 +1233,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1246,8 +1253,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1257,8 +1264,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1281,8 +1288,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1296,8 +1303,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1312,8 +1319,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1321,8 +1328,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -1331,8 +1338,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "chrono",
@@ -1350,8 +1357,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1372,8 +1379,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1386,8 +1393,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "chrono",
@@ -1403,8 +1410,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1422,8 +1429,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -1458,11 +1465,10 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
- "chrono",
  "datafusion-catalog",
  "datafusion-catalog-listing",
  "datafusion-common",
@@ -1485,8 +1491,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto-common"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1495,17 +1501,18 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto-models"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
+ "datafusion-common",
  "datafusion-proto-common",
  "prost",
 ]
 
 [[package]]
 name = "datafusion-pruning"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1564,8 +1571,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -1578,8 +1585,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-spark"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -1607,8 +1614,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -1626,8 +1633,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-substrait"
-version = "54.1.0"
-source = "git+https://github.com/apache/datafusion?rev=dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48#dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48"
+version = "55.0.0"
+source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2446,9 +2453,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 dependencies = [
  "twox-hash",
 ]
@@ -2520,6 +2527,16 @@ name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2639,9 +2656,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5302d4da74d6596a1f11f9928767995b53bca657cbeea1e4e8c5074f8a1157dd"
+checksum = "7065842956a20c2a536924ce8e4d9955f7422451511b9eb7500d7bfe5077e59c"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -2650,7 +2667,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64 0.22.1",
+ "base64 0.23.1",
  "brotli",
  "bytes",
  "chrono",
@@ -2659,11 +2676,10 @@ dependencies = [
  "half",
  "hashbrown 0.17.1",
  "lz4_flex",
- "num-bigint",
+ "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
  "object_store",
- "paste",
  "seq-macro",
  "simdutf8",
  "snap",
@@ -2671,12 +2687,6 @@ dependencies = [
  "twox-hash",
  "zstd",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbjson"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,16 +40,16 @@ arrow = { version = "59" }
 arrow-array = { version = "59" }
 arrow-schema = { version = "59" }
 arrow-select = { version = "59" }
-datafusion = { version = "54.1.0" }
-datafusion-substrait = { version = "54.1.0" }
-datafusion-proto = { version = "54.1.0" }
-datafusion-ffi = { version = "54.1.0" }
-datafusion-catalog = { version = "54.1.0", default-features = false }
-datafusion-common = { version = "54.1.0", default-features = false }
-datafusion-functions-aggregate = { version = "54.1.0" }
-datafusion-functions-window = { version = "54.1.0" }
-datafusion-spark = { version = "54.1.0" }
-datafusion-expr = { version = "54.1.0" }
+datafusion = { version = "55.0.0" }
+datafusion-substrait = { version = "55.0.0" }
+datafusion-proto = { version = "55.0.0" }
+datafusion-ffi = { version = "55.0.0" }
+datafusion-catalog = { version = "55.0.0", default-features = false }
+datafusion-common = { version = "55.0.0", default-features = false }
+datafusion-functions-aggregate = { version = "55.0.0" }
+datafusion-functions-window = { version = "55.0.0" }
+datafusion-spark = { version = "55.0.0" }
+datafusion-expr = { version = "55.0.0" }
 prost = "0.14.3"
 serde_json = "1"
 uuid = { version = "1.23" }
@@ -72,13 +72,13 @@ codegen-units = 2
 # We cannot publish to crates.io with any patches in the below section. Developers
 # must remove any entries in this section before creating a release candidate.
 [patch.crates-io]
-datafusion = { git = "https://github.com/apache/datafusion", rev = "dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48" }
-datafusion-substrait = { git = "https://github.com/apache/datafusion", rev = "dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48" }
-datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48" }
-datafusion-ffi = { git = "https://github.com/apache/datafusion", rev = "dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48" }
-datafusion-catalog = { git = "https://github.com/apache/datafusion", rev = "dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48" }
-datafusion-common = { git = "https://github.com/apache/datafusion", rev = "dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48" }
-datafusion-functions-aggregate = { git = "https://github.com/apache/datafusion", rev = "dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48" }
-datafusion-functions-window = { git = "https://github.com/apache/datafusion", rev = "dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48" }
-datafusion-spark = { git = "https://github.com/apache/datafusion", rev = "dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48" }
-datafusion-expr = { git = "https://github.com/apache/datafusion", rev = "dbcb5c0f729e9ef6b0ab4c79253fe3b657929f48" }
+datafusion = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc2" }
+datafusion-substrait = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc2" }
+datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc2" }
+datafusion-ffi = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc2" }
+datafusion-catalog = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc2" }
+datafusion-common = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc2" }
+datafusion-functions-aggregate = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc2" }
+datafusion-functions-window = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc2" }
+datafusion-spark = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc2" }
+datafusion-expr = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc2" }

--- a/crates/core/src/dataset_exec.rs
+++ b/crates/core/src/dataset_exec.rs
@@ -21,11 +21,12 @@ use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::error::{ArrowError, Result as ArrowResult};
 use datafusion::arrow::pyarrow::PyArrowType;
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::tree_node::TreeNodeRecursion;
 use datafusion::error::{DataFusionError as InnerDataFusionError, Result as DFResult};
 use datafusion::execution::context::TaskContext;
 use datafusion::logical_expr::Expr;
 use datafusion::logical_expr::utils::conjunction;
-use datafusion::physical_expr::{EquivalenceProperties, LexOrdering};
+use datafusion::physical_expr::{EquivalenceProperties, LexOrdering, PhysicalExpr};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
@@ -163,6 +164,15 @@ impl ExecutionPlan for DatasetExec {
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         // this is a leaf node and has no children
         vec![]
+    }
+
+    fn apply_expressions(
+        &self,
+        _f: &mut dyn FnMut(&Arc<dyn PhysicalExpr>) -> DFResult<TreeNodeRecursion>,
+    ) -> DFResult<TreeNodeRecursion> {
+        // Any filters are pushed down into the PyArrow dataset scanner as pyarrow
+        // expressions, so this node owns no physical expressions to visit.
+        Ok(TreeNodeRecursion::Continue)
     }
 
     fn with_new_children(


### PR DESCRIPTION
As part of both preparing for the next datafusion-python release and testing the upstream datafusion release, this PR updates our crates patch to use the upstream release candidate.