### PR TITLE
docs: Add docstring examples to the unparser module

### DIFF
--- a/python/datafusion/unparser.py
+++ b/python/datafusion/unparser.py
@@ -25,7 +25,12 @@ from .plan import LogicalPlan
 
 
 class Dialect:
-    """DataFusion data catalog."""
+    """The SQL dialect an :py:class:`Unparser` writes.
+
+    The dialect decides how the generated SQL is spelled - most visibly how
+    identifiers are quoted - so the same logical plan produces different SQL
+    text for each dialect.
+    """
 
     def __init__(self, dialect: unparser_internal.Dialect) -> None:
         """This constructor is not typically called by the end user."""
@@ -33,43 +38,122 @@ class Dialect:
 
     @staticmethod
     def default() -> "Dialect":
-        """Create a new default dialect."""
+        """Create a new default dialect.
+
+        This dialect leaves identifiers unquoted.
+
+        Example usage:
+
+        >>> ctx = dfn.SessionContext()
+        >>> _ = ctx.from_pydict({"a": [1, 2, 3], "b": [10, 20, 30]}, name="t")
+        >>> plan = ctx.sql("SELECT a FROM t").logical_plan()
+        >>> Unparser(Dialect.default()).plan_to_sql(plan)
+        'SELECT t.a FROM t'
+        """
         return Dialect(unparser_internal.Dialect.default())
 
     @staticmethod
     def mysql() -> "Dialect":
-        """Create a new MySQL dialect."""
+        """Create a new MySQL dialect.
+
+        This dialect quotes identifiers with backticks.
+
+        Example usage:
+
+        >>> ctx = dfn.SessionContext()
+        >>> _ = ctx.from_pydict({"a": [1, 2, 3], "b": [10, 20, 30]}, name="t")
+        >>> plan = ctx.sql("SELECT a FROM t").logical_plan()
+        >>> Unparser(Dialect.mysql()).plan_to_sql(plan)
+        'SELECT `t`.`a` FROM `t`'
+        """
         return Dialect(unparser_internal.Dialect.mysql())
 
     @staticmethod
     def postgres() -> "Dialect":
-        """Create a new PostgreSQL dialect."""
+        """Create a new PostgreSQL dialect.
+
+        This dialect quotes identifiers with double quotes.
+
+        Example usage:
+
+        >>> ctx = dfn.SessionContext()
+        >>> _ = ctx.from_pydict({"a": [1, 2, 3], "b": [10, 20, 30]}, name="t")
+        >>> plan = ctx.sql("SELECT a FROM t").logical_plan()
+        >>> Unparser(Dialect.postgres()).plan_to_sql(plan)
+        'SELECT "t"."a" FROM "t"'
+        """
         return Dialect(unparser_internal.Dialect.postgres())
 
     @staticmethod
     def sqlite() -> "Dialect":
-        """Create a new SQLite dialect."""
+        """Create a new SQLite dialect.
+
+        This dialect quotes identifiers with backticks.
+
+        Example usage:
+
+        >>> ctx = dfn.SessionContext()
+        >>> _ = ctx.from_pydict({"a": [1, 2, 3], "b": [10, 20, 30]}, name="t")
+        >>> plan = ctx.sql("SELECT a FROM t").logical_plan()
+        >>> Unparser(Dialect.sqlite()).plan_to_sql(plan)
+        'SELECT `t`.`a` FROM `t`'
+        """
         return Dialect(unparser_internal.Dialect.sqlite())
 
     @staticmethod
     def duckdb() -> "Dialect":
-        """Create a new DuckDB dialect."""
+        """Create a new DuckDB dialect.
+
+        This dialect quotes identifiers with double quotes.
+
+        Example usage:
+
+        >>> ctx = dfn.SessionContext()
+        >>> _ = ctx.from_pydict({"a": [1, 2, 3], "b": [10, 20, 30]}, name="t")
+        >>> plan = ctx.sql("SELECT a FROM t").logical_plan()
+        >>> Unparser(Dialect.duckdb()).plan_to_sql(plan)
+        'SELECT "t"."a" FROM "t"'
+        """
         return Dialect(unparser_internal.Dialect.duckdb())
 
 
 class Unparser:
-    """DataFusion unparser."""
+    """Converts a :py:class:`~datafusion.plan.LogicalPlan` back into SQL text."""
 
     def __init__(self, dialect: Dialect) -> None:
         """This constructor is not typically called by the end user."""
         self.unparser = unparser_internal.Unparser(dialect.dialect)
 
     def plan_to_sql(self, plan: LogicalPlan) -> str:
-        """Convert a logical plan to a SQL string."""
+        """Convert a logical plan to a SQL string.
+
+        Example usage:
+
+        >>> ctx = dfn.SessionContext()
+        >>> _ = ctx.from_pydict({"a": [1, 2, 3], "b": [10, 20, 30]}, name="t")
+        >>> plan = ctx.sql("SELECT a, b FROM t WHERE a > 1").logical_plan()
+        >>> Unparser(Dialect.default()).plan_to_sql(plan)
+        'SELECT t.a, t.b FROM t WHERE (t.a > 1)'
+        """
         return self.unparser.plan_to_sql(plan._raw_plan)
 
     def with_pretty(self, pretty: bool) -> "Unparser":
-        """Set the pretty flag."""
+        """Set the pretty flag.
+
+        When set, redundant parentheses are omitted from the generated SQL.
+        The unparser is modified in place and returned, so the call can be
+        chained.
+
+        Example usage:
+
+        >>> ctx = dfn.SessionContext()
+        >>> _ = ctx.from_pydict({"a": [1, 2, 3], "b": [10, 20, 30]}, name="t")
+        >>> plan = ctx.sql("SELECT a, b FROM t WHERE a > 1").logical_plan()
+        >>> Unparser(Dialect.default()).plan_to_sql(plan)
+        'SELECT t.a, t.b FROM t WHERE (t.a > 1)'
+        >>> Unparser(Dialect.default()).with_pretty(True).plan_to_sql(plan)
+        'SELECT t.a, t.b FROM t WHERE t.a > 1'
+        """
         self.unparser = self.unparser.with_pretty(pretty)
         return self
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1691.

# Rationale for this change

`AGENTS.md` requires every public Python function to carry a usage example, and
no public function in `python/datafusion/unparser.py` had one. The omission is
most costly in this module: the reason `Dialect` exists is that dialects render
the same plan differently, and nothing in the documentation showed that.

# What changes are included in this PR?

* Docstring examples for `Dialect.default`, `Dialect.mysql`, `Dialect.postgres`,
  `Dialect.sqlite`, `Dialect.duckdb`, `Unparser.plan_to_sql` and
  `Unparser.with_pretty`. All build the same input table so the examples differ
  only in the behaviour being demonstrated, and each shows the actual quoting a
  dialect produces:

  ```
  >>> Unparser(Dialect.default()).plan_to_sql(plan)
  'SELECT t.a FROM t'
  >>> Unparser(Dialect.mysql()).plan_to_sql(plan)
  'SELECT `t`.`a` FROM `t`'
  >>> Unparser(Dialect.postgres()).plan_to_sql(plan)
  'SELECT "t"."a" FROM "t"'
  ```

* Corrected the `Dialect` class summary, which read `"DataFusion data catalog."`

* Described what `with_pretty` does — it drops redundant parentheses and returns
  the same unparser so the call can be chained — instead of restating its name.

No behaviour is changed; the diff is docstrings only.

# Are there any user-facing changes?

Documentation only. The new examples run as doctests under the existing
`--doctest-modules` setting, so they are checked in CI.
