### PR TITLE
chore: use DataFusion 55.0.0 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,8 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f76f0167ed0842b29a3d1e41be3c034c0a46409a3a703cc4cc84ee8c24abf4"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -845,7 +846,8 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d79ec3460f6ed5c58f9b3f2d873fbc77748b82653bff1b4cdaf06de33bb4e05f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -869,7 +871,8 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b48cef241e2efcfd496fe05ae4d0d5de20793451862faefe406c397a467e12d4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -892,7 +895,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f72810485975c258f1b4d00baab31728470676c60c5546f366ebd0d99f05ab6"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -918,7 +922,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533c28e75dba52f41bde187d23a1cb24ab91c7c097966824fa471e67b60320ea"
 dependencies = [
  "futures",
  "log",
@@ -928,7 +933,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b00a1fa0da26f6087136a82fea7f13c76a672cbab452d4086952a7cf770a19b"
 dependencies = [
  "arrow",
  "async-compression",
@@ -964,7 +970,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad17ec881bff2ed7768b4bfe971d3efbf3473f2fd1f9d365447bccbdf908678"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -988,7 +995,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-avro"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c9587cff8163f9bfcb186e8664ba85cb327031b8ff14330307f961ea2fc196"
 dependencies = [
  "arrow",
  "arrow-avro",
@@ -1006,7 +1014,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5345285b0c3eaab412e7539b706973c083bd7e5bce575de5e0a3da488d08d1d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1029,7 +1038,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da02fb9324f56bd8c53f1ee2e949547425cb66f76adc6832b10d44f80a1221d2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1052,7 +1062,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c0b0dc1453952952fd5c69ad1c7f6042176e69ed233011d47e07cf74ed0949e"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1084,12 +1095,14 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88fd985bc0550c36f557db69543cc9d6393b1509783520b30e902f23c555da6"
 
 [[package]]
 name = "datafusion-execution"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a98f1052f91b4991f0bf2ce1e4e36dfbdcda454a956b8c8d562c7c845e8fce1d"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1114,7 +1127,8 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464625a1f0e4b9df552d894fafcc8aac953ebbc8b0fa0acdaf20975fd615040e"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1138,7 +1152,8 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604994999d5aeca1d1df645ffc98bc787447aaff05dde27aad0342b48fc1fe0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1149,7 +1164,8 @@ dependencies = [
 [[package]]
 name = "datafusion-ffi"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada11061028faad12bf1a45f2d5fa6624b7fcf65274fbf10a71ffe46c77cd10b"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1203,7 +1219,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051e97533e6af53e4aa0a0667cadc886abcaf36c4a5925019c55c0aa4c218fde"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1234,7 +1251,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0f1bb166d3572b6ed40e1afb2faaacade962abc08c2fcf04babee74681c56b"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1254,7 +1272,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ed756770f5f98369e181d692fd5ee6b1127ffd7322caba92f3730f9f5c92333"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1265,7 +1284,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91173fdb5c0ff2a41169a8ffa1b385b8844f18728747bb0a37e35ad7d5772a4f"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1289,7 +1309,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1bcdfb286a745461b126719c32700777e83df4f17cc44db5d71ebce5731e840"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1304,7 +1325,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec4b508f1f93f00038ba3e737e894ec6c775528b4369413386655ae6125f0fc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1320,7 +1342,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b352020834140073fbf5b46ee0ceb926e5074a9d0bcae1dbd91d0586d999cde"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1329,7 +1352,8 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15192effab05d38cce10e92a6fb48c967b5f166b27b7195a165a72b232569c58"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -1339,7 +1363,8 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854445d9f7847e1e46089cf61b8d341a64382f14484e912c83a0f23b31216896"
 dependencies = [
  "arrow",
  "chrono",
@@ -1358,7 +1383,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671558dad1d2aa253c39c0a4c52515958b99eb91abf649f4b88d5e69cc55282f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1380,7 +1406,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffae3d78c2da80ecc829cb58536cc5aca2e99cf1365eda694fc75bfe288861e0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1394,7 +1421,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d9092ed15e7203fbd0903215172f7c9d18f10d94cba35137f3b3836f7c46f16"
 dependencies = [
  "arrow",
  "chrono",
@@ -1411,7 +1439,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9005b6cf50b57b72d476c6ed4662b04be7ca6be5320ba9127c6d0b7e4218095b"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1430,7 +1459,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787e4fcff4adc4fce8948441103a99705018b49c8dff0720b650bd7a15da112"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -1466,7 +1496,8 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df0504eb9028d5e01f481af3519cde3f97ab650fd50ce7b787e94b69a7a193c"
 dependencies = [
  "arrow",
  "datafusion-catalog",
@@ -1492,7 +1523,8 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92415a2442964f180d39cdcd8ff1edd99f9260c1499ba80a396499c2154d11"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1502,7 +1534,8 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-models"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e4c0bd6af4fcabdbe201ee86fbeef2ac423a44e1d8fda56d994c9e2d1d3ad2"
 dependencies = [
  "datafusion-common",
  "datafusion-proto-common",
@@ -1512,7 +1545,8 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e651c8df0b90daed6a7be5921ec0ee379e6909705f063eeff70fd4e35010e4c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1572,7 +1606,8 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb56667ee38217efab19b895d9a936052cfb47ed438a19663351bdc42a6214a1"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -1586,7 +1621,8 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "992dd0b954f24cb576cbeee3555c3083b9cf7a5a5f2448ea25f7a437d444163f"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -1615,7 +1651,8 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c29067cb9d32f8e603c45e15d61ea18f1069f96ceafeceb4e18466b8e5b31d9"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -1634,7 +1671,8 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion?rev=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c026ddbbc33c34d0fac95a9620367c805ad6a7174cac52b57f360746c3e282"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,13 +72,3 @@ codegen-units = 2
 # We cannot publish to crates.io with any patches in the below section. Developers
 # must remove any entries in this section before creating a release candidate.
 [patch.crates-io]
-datafusion = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc3" }
-datafusion-substrait = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc3" }
-datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc3" }
-datafusion-ffi = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc3" }
-datafusion-catalog = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc3" }
-datafusion-common = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc3" }
-datafusion-functions-aggregate = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc3" }
-datafusion-functions-window = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc3" }
-datafusion-spark = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc3" }
-datafusion-expr = { git = "https://github.com/apache/datafusion", rev = "55.0.0-rc3" }


### PR DESCRIPTION
# Which issue does this PR close?

N/A — this is release follow-up maintenance, matching the equivalent change made for DataFusion 54 in #1588.

# Rationale for this change

`main` currently pins the DataFusion crates to the `55.0.0-rc3` git tag via `[patch.crates-io]`. DataFusion 55.0.0 has since been published to crates.io, so the patch is no longer needed.

The patch entries also block publishing: `dev/check_crates_patch.py` (run by the `check-crates-patch` CI job) fails while any entries are present, since release builds must not depend on patched crates.

# What changes are included in this PR?

- Remove all `[patch.crates-io]` entries from `Cargo.toml`. The section header and its explanatory comment are kept (an empty section is explicitly allowed by `dev/check_crates_patch.py`), so future development patches have an obvious home.
- Regenerate `Cargo.lock` so the DataFusion crates resolve from the crates.io registry instead of `git+https://github.com/apache/datafusion?rev=55.0.0-rc3`.

The declared dependency versions in `[workspace.dependencies]` were already `55.0.0`, so no version numbers changed and no source changes were required.

# Are there any user-facing changes?

No. The resolved DataFusion version is unchanged — 55.0.0-rc3 and the 55.0.0 release are the same code, only the source moves from git to crates.io.