### PR TITLE
docs: explain S3 object-store configuration for SQL

### DIFF
--- a/docs/source/user-guide/data-sources.md
+++ b/docs/source/user-guide/data-sources.md
@@ -100,10 +100,15 @@ Supported Object Stores are
 - {py:class}`~datafusion.object_store.MicrosoftAzure`
 
 ```python
+import os
+
+from datafusion import SessionContext
 from datafusion.object_store import AmazonS3
 
 region = "us-east-1"
 bucket_name = "yellow-trips"
+
+ctx = SessionContext()
 
 s3 = AmazonS3(
     bucket_name=bucket_name,
@@ -118,6 +123,28 @@ ctx.register_object_store("s3://", s3, None)
 ctx.register_parquet("trips", path)
 
 ctx.table("trips").show()
+```
+
+### Use S3 in SQL
+
+Configure S3 access on an {py:class}`~datafusion.object_store.AmazonS3` object and
+register it on the context before issuing SQL that uses an `s3://` location. AWS
+credentials are not SQL `OPTIONS`: `aws.*` is not a recognized SQL configuration
+namespace.
+
+After registering the object store above, a SQL external table can use the same
+S3 path:
+
+```python
+ctx.sql(
+    f"""
+    CREATE EXTERNAL TABLE trips_sql
+    STORED AS PARQUET
+    LOCATION '{path}'
+    """
+).collect()
+
+ctx.sql("SELECT count(passenger_count) FROM trips_sql").show()
 ```
 
 ## Other DataFrame Libraries


### PR DESCRIPTION
# Which issue does this PR close?

None. Related to #970, which remains open: this PR does not implement the requested `aws.*` SQL options.

# Rationale for this change

The Python object-store guide demonstrates `register_parquet` but does not show how to create and query a SQL external table using the same registered store. This is a documentation improvement for that existing workflow.

# What changes are included in this PR?

- Show the imports, context setup, environment credential prerequisites, and bucket-specific object-store registration.
- Demonstrate `CREATE EXTERNAL TABLE` and a SQL query using that store.
- Add a network-free Python test that reads Parquet through an `s3://` URL backed by a registered `LocalFileSystem` and checks the rows and non-null count.

# Are there any user-facing changes?

Documentation only; no runtime API or SQL-option support changes.

Validation: 26 object-store tests pass, all 10 Python/code-cell snippets parse, applicable pre-commit hooks and `git diff --check` pass. Both S3 documentation snippets also read three rows and return a non-null count of 2 against a loopback Moto server, adapting only the endpoint and HTTP allowance and using dummy environment credentials. The original #970 SQL still fails with `Could not find config namespace "aws"`, including after store registration.

Tests used an existing locally built 54.0.0 wheel from commit `cee8a5d33db5dd7cf40f9a07cc6e2764c818db6c`; its `crates/core/src` and `python/datafusion` sources match this branch. This is not a fresh wheel build from this PR head. No real AWS credentials or AWS SDK credential-chain behavior were validated.

AI-assisted documentation, test, and review follow-up. This PR retains the documentation-only scope; #970’s requested inline AWS SQL options remain separate.

