### PR TITLE
test: run hermetic user examples in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,12 @@ jobs:
           # free-threaded build and re-pick the system 3.12 (see install step).
           uv run --python "$PWD/.venv/bin/python" --no-project pytest -v --import-mode=importlib
 
-      # FFI + TPC-H examples only need to run once; gate to abi3 entries.
+      # User, FFI, and TPC-H examples only need to run once; gate to abi3 entries.
+      - name: Run hermetic user examples
+        if: matrix.wheel-tag == 'abi3'
+        run: |
+          uv run --python "$PWD/.venv/bin/python" --no-project pytest examples/_tests.py
+
       - name: FFI unit tests
         if: matrix.wheel-tag == 'abi3'
         run: |

--- a/examples/_tests.py
+++ b/examples/_tests.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Run the top-level examples that require no external resources."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+EXAMPLES = (
+    "array-operations.py",
+    "create-context.py",
+    "query-pyarrow-data.py",
+    "python-udf.py",
+)
+
+
+@pytest.mark.parametrize("example", EXAMPLES)
+def test_example_runs(example: str) -> None:
+    """Run one hermetic user example with the installed DataFusion package."""
+    examples_dir = Path(__file__).parent
+    subprocess.run(  # noqa: S603 -- `example` is selected from the module allowlist.
+        [sys.executable, examples_dir / example],
+        check=True,
+        cwd=examples_dir.parent,
+    )


### PR DESCRIPTION
# Which issue does this PR close?

Closes #888.

# Rationale for this change

The CI workflow runs the dedicated TPC-H examples, but it does not execute the ordinary top-level user examples. These scripts are executable documentation and can drift when the public API changes.

# What changes are included in this PR?

- Add `examples/_tests.py`, a subprocess runner for four self-contained examples: `array-operations.py`, `create-context.py`, `query-pyarrow-data.py`, and `python-udf.py`.
- Run that runner once on the ABI3 wheel after CI installs the built wheel, alongside the existing FFI and TPC-H example checks.
- Keep examples that need credentials, network access, fixture data, or optional integrations out of this first increment.

# Are there any user-facing changes?

No API behavior changes. CI will now detect regressions in these four executable user examples.
