### PR TITLE
fix: show results in the nine silent top-level examples

### DIFF
--- a/examples/export.py
+++ b/examples/export.py
@@ -50,3 +50,6 @@ assert pylist == [{"a": 1, "b": 4}, {"a": 2, "b": 5}, {"a": 3, "b": 6}]
 # export to Python dictionary of columns
 pydict = df.to_pydict()
 assert pydict == {"a": [1, 2, 3], "b": [4, 5, 6]}
+
+print(f"Exported as list of rows: {pylist}")
+print(f"Exported as dict of columns: {pydict}")

--- a/examples/import.py
+++ b/examples/import.py
@@ -55,3 +55,6 @@ assert type(df) is datafusion.DataFrame
 arrow_table = pa.Table.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
 df = ctx.from_arrow(arrow_table)
 assert type(df) is datafusion.DataFrame
+
+# Display the last converted DataFrame
+df.show()

--- a/examples/python-udaf.py
+++ b/examples/python-udaf.py
@@ -67,3 +67,5 @@ df = df.aggregate([], [my_udaf(col("a"))])
 result = df.collect()[0]
 
 assert result.column(0) == pa.array([6.0])
+
+print(f"Sum of column 'a': {result.column(0)[0].as_py()}")

--- a/examples/python-udf.py
+++ b/examples/python-udf.py
@@ -38,6 +38,8 @@ df = ctx.create_dataframe([[batch]])
 
 df = df.select(is_null_arr(f.col("a")))
 
+df.show()
+
 result = df.collect()[0]
 
 assert result.column(0) == pa.array([False] * 3)

--- a/examples/query-pyarrow-data.py
+++ b/examples/query-pyarrow-data.py
@@ -35,6 +35,8 @@ df = df.select(
     col("a") - col("b"),
 )
 
+df.show()
+
 # execute and collect the first (and only) batch
 result = df.collect()[0]
 

--- a/examples/sql-to-pandas.py
+++ b/examples/sql-to-pandas.py
@@ -40,3 +40,5 @@ fig = pandas_df.plot(
     kind="bar", title="Trip Count by Number of Passengers"
 ).get_figure()
 fig.savefig("chart.png")
+
+print("Saved chart to chart.png")

--- a/examples/sql-using-python-udaf.py
+++ b/examples/sql-using-python-udaf.py
@@ -75,6 +75,7 @@ ctx.register_udaf(my_udaf)
 result_df = ctx.sql(
     "select a, my_accumulator(b) as b_aggregated from t group by a order by a"
 )
+result_df.show()
 # Dataframe:
 # +---+--------------+
 # | a | b_aggregated |

--- a/examples/sql-using-python-udf.py
+++ b/examples/sql-using-python-udf.py
@@ -53,6 +53,7 @@ ctx.register_udf(is_null_arr)
 
 # Query the DataFrame using SQL
 result_df = ctx.sql("select a, is_null(b) as b_is_null from t")
+result_df.show()
 # Dataframe:
 # +---+-----------+
 # | a | b_is_null |

--- a/examples/substrait.py
+++ b/examples/substrait.py
@@ -47,3 +47,5 @@ df_logical_plan = ss.Consumer.from_substrait_plan(ctx, substrait_plan)
 # Back to Substrait Plan just for demonstration purposes
 # type(substrait_plan) -> <class 'datafusion.substrait.plan'>
 substrait_plan = ss.Producer.to_substrait_plan(df_logical_plan, ctx)
+
+print(f"Substrait plan round-trip complete: {len(substrait_bytes)} encoded bytes")


### PR DESCRIPTION
# Which issue does this PR close?

Part of #1728.

# Rationale for this change

Issue #1728 documents two example-side problems. The self-contained `csv-read-options.py` fix is already covered by #1729; this PR addresses the other half: nine top-level examples (`export.py`, `import.py`, `python-udaf.py`, `python-udf.py`, `query-pyarrow-data.py`, `sql-to-pandas.py`, `sql-using-python-udaf.py`, `sql-using-python-udf.py`, `substrait.py`) end in bare `assert`s and print nothing, so running them gives a reader no output and a silent script is indistinguishable from a broken one.

# What changes are included in this PR?

- Each of the nine examples now ends with a terminal `df.show()` or `print(...)` showing its final result; the existing asserts are kept unchanged.
- No workflow or CI changes are included — the missing CI job from the issue is being designed in #1717.
- No file overlaps with #1717 or #1729.

# Are there any user-facing changes?

No API changes. The examples are documentation; after this change they visibly print their results when run.

Testing: ran all nine scripts with the released `datafusion` 54.0.0 wheel on Python 3.12 (macOS ARM). `sql-to-pandas.py` was additionally verified end-to-end with the NYC taxi parquet documented in `examples/README.md` (generated `chart.png` removed afterwards). `ruff check` / `ruff format` (v0.15.1 as pinned in `.pre-commit-config.yaml`) and `codespell` pass on the changed files.

Prepared with AI assistance (agent contribution).